### PR TITLE
pin NumPy requirement to 1.19

### DIFF
--- a/components/conda.yml
+++ b/components/conda.yml
@@ -4,3 +4,4 @@ channels:
   - defaults
 dependencies:
   - mlflow=1.14.1
+  - numpy=1.19

--- a/components/get_data/conda.yml
+++ b/components/get_data/conda.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip=20.3.3
   - requests=2.24.0
   - mlflow=1.14.1
+  - numpy=1.19
   - pip:
       - wandb==0.10.31
       - git+https://github.com/udacity/nd0821-c2-build-model-workflow-starter.git#egg=wandb-utils&subdirectory=components

--- a/components/test_regression_model/conda.yml
+++ b/components/test_regression_model/conda.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip=20.3.3
   - mlflow=1.14.1
   - scikit-learn=0.24.1
+  - numpy=1.19
   - pip:
       - wandb==0.10.31
       - git+https://github.com/udacity/nd0821-c2-build-model-workflow-starter.git#egg=wandb-utils&subdirectory=components

--- a/components/train_val_test_split/conda.yml
+++ b/components/train_val_test_split/conda.yml
@@ -7,6 +7,7 @@ dependencies:
   - requests=2.24.0
   - mlflow=1.14.1
   - scikit-learn=0.24.1
+  - numpy=1.19
   - pip:
       - wandb==0.10.31
       - git+https://github.com/udacity/nd0821-c2-build-model-workflow-starter.git#egg=wandb-utils&subdirectory=components

--- a/conda.yml
+++ b/conda.yml
@@ -7,5 +7,6 @@ dependencies:
   - pyyaml=5.3.1
   - hydra-core=1.0.6
   - pip=20.3.3
+  - numpy=1.19
   - pip:
       - wandb==0.10.31

--- a/environment.yml
+++ b/environment.yml
@@ -13,5 +13,6 @@ dependencies:
   - pandas=1.2.3
   - git=2.30.2
   - pip=20.3.3
+  - numpy=1.19
   - pip:
       - wandb==0.10.31

--- a/src/train_random_forest/conda.yml
+++ b/src/train_random_forest/conda.yml
@@ -9,5 +9,6 @@ dependencies:
   - scikit-learn=0.24.1
   - matplotlib=3.2.2
   - pillow=8.1.2
+  - numpy=1.19
   - pip:
       - wandb==0.10.21


### PR DESCRIPTION
The current YAML specifies `mlflow=1.14.1` (March 2021 version), which uses the now-deprecated `np.object`. This PR attempts to recreate the environment that the original developer had by pinning NumPy to 1.19, which is the last version of NumPy before [`np.object` was deprecated in January 2021](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated)