### PR TITLE
Libraries Versions for Project Build ML Pipeline for Short Term Rental Prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,10 +340,11 @@ with the cleaned data:
                     so we must add it to ``conda.yml`` file, including a version:
    ```yaml
    dependencies:
-     - pip=20.3.3
-     - pandas=1.2.3
+     - pip=23.3.1
+     - pandas=2.1.3
      - pip:
-         - wandb==0.10.31
+         - mlflow==2.8.1
+         - wandb==0.16.0
    ```
    
 4. Add the ``basic_cleaning`` step to the pipeline (the ``main.py`` file):

--- a/components/conda.yml
+++ b/components/conda.yml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - mlflow=1.14.1
+  - mlflow=2.8.1

--- a/components/get_data/conda.yml
+++ b/components/get_data/conda.yml
@@ -3,9 +3,9 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pip=20.3.3
+  - pip=23.3.1
   - requests=2.24.0
-  - mlflow=1.14.1
   - pip:
-      - wandb==0.10.31
+      - mlflow==2.8.1
+      - wandb==0.16.0
       - git+https://github.com/udacity/nd0821-c2-build-model-workflow-starter.git#egg=wandb-utils&subdirectory=components

--- a/components/test_regression_model/conda.yml
+++ b/components/test_regression_model/conda.yml
@@ -3,10 +3,12 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pandas=1.1.4
-  - pip=20.3.3
-  - mlflow=1.14.1
-  - scikit-learn=0.24.1
+  - python=3.10.0
+  - pip=23.3.1
+  - requests=2.24.0
+  - scikit-learn=1.3.2
+  - pandas=2.1.3
   - pip:
-      - wandb==0.10.31
+      - mlflow==2.8.1
+      - wandb==0.16.0
       - git+https://github.com/udacity/nd0821-c2-build-model-workflow-starter.git#egg=wandb-utils&subdirectory=components

--- a/components/train_val_test_split/conda.yml
+++ b/components/train_val_test_split/conda.yml
@@ -3,10 +3,11 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pip=20.3.3
+  - python=3.10.0
+  - pip=23.3.1
   - requests=2.24.0
-  - mlflow=1.14.1
-  - scikit-learn=0.24.1
+  - scikit-learn=1.3.2
   - pip:
-      - wandb==0.10.31
+      - mlflow==2.8.1
+      - wandb==0.16.0
       - git+https://github.com/udacity/nd0821-c2-build-model-workflow-starter.git#egg=wandb-utils&subdirectory=components

--- a/conda.yml
+++ b/conda.yml
@@ -3,9 +3,10 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - mlflow=1.14.1
-  - pyyaml=5.3.1
-  - hydra-core=1.0.6
-  - pip=20.3.3
+  - python=3.10
+  - pyyaml
+  - hydra-core=1.3.2
+  - pip=23.3.1
   - pip:
-      - wandb==0.10.31
+      - mlflow==2.8.1
+      - wandb==0.16.0

--- a/config.yaml
+++ b/config.yaml
@@ -32,7 +32,7 @@ modeling:
     min_samples_leaf: 3
     # Here -1 means all available cores
     n_jobs: -1
-    criterion: mae
+    criterion: squared_error
     max_features: 0.5
     # DO not change the following
     oob_score: true

--- a/cookie-mlflow-step/{{cookiecutter.step_name}}/conda.yml
+++ b/cookie-mlflow-step/{{cookiecutter.step_name}}/conda.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pip=20.3.3
+  - pip=23.3.1
   - pip:
-      - wandb==0.10.31
+      - mlflow==2.8.1
+      - wandb==0.16.0

--- a/environment.yml
+++ b/environment.yml
@@ -3,15 +3,12 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - mlflow=1.14.1
-  - ipython=7.21.0
-  - notebook=6.2.0
-  - jupyterlab=3.0.10
-  - cookiecutter=1.7.2
-  - hydra-core=1.0.6
-  - matplotlib=3.3.4
-  - pandas=1.2.3
-  - git=2.30.2
-  - pip=20.3.3
+  - python=3.10
+  - hydra-core=1.3.2
+  - matplotlib=3.8.2
+  - pandas=2.1.3
+  - jupyterlab=4.0.9
+  - pip=23.3.1
   - pip:
-      - wandb==0.10.31
+      - mlflow==2.8.1
+      - wandb==0.16.0

--- a/src/data_check/conda.yml
+++ b/src/data_check/conda.yml
@@ -3,9 +3,11 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pandas=1.1.4
+  - python=3.10.0
+  - pandas=2.1.3
   - pytest=6.2.2
   - scipy=1.5.2
-  - pip=20.3.3
+  - pip=23.3.1
   - pip:
-      - wandb==0.10.21
+      - mlflow==2.8.1
+      - wandb==0.16.0

--- a/src/eda/conda.yml
+++ b/src/eda/conda.yml
@@ -3,11 +3,12 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - jupyterlab=3.0.12
-  - seaborn=0.11.1
-  - pandas=1.2.3
-  - pip=20.3.3
-  - pandas-profiling=2.11.0
-  - pyarrow=2.0
+  - python=3.10
+  - hydra-core=1.3.2
+  - matplotlib=3.8.2
+  - pandas=2.1.3
+  - pip=23.3.1
+  - scikit-learn=1.3.2
   - pip:
-      - wandb==0.10.31
+      - mlflow==2.8.1
+      - wandb==0.16.0

--- a/src/train_random_forest/conda.yml
+++ b/src/train_random_forest/conda.yml
@@ -3,11 +3,12 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pandas=1.1.4
-  - pip=20.3.3
-  - mlflow=1.14.1
-  - scikit-learn=0.24.1
-  - matplotlib=3.2.2
-  - pillow=8.1.2
+  - python=3.10
+  - hydra-core=1.3.2
+  - matplotlib=3.8.2
+  - pandas=2.1.3
+  - pip=23.3.1
+  - scikit-learn=1.3.2
   - pip:
-      - wandb==0.10.21
+      - mlflow==2.8.1
+      - wandb==0.16.0


### PR DESCRIPTION
Fix all libraries versions considering the mlflow latest version. Also, changed the config.yaml for hyperparameter criterion in the Random Forest model.

- mlflow=2.8.1
- wandb=0.16.0
- pandas=2.1.3
- pip=23.3.1
- scikit-learn=1.3.2
- hydra-core=1.3.2