### PR TITLE
More python3.13 changes required for the project to run

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -3,7 +3,7 @@
 In order to run these components you need to have conda (Miniconda or Anaconda) and MLflow installed.
 Install it with::
 
-    > conda install mlflow=2.8.1
+    > conda install mlflow=3.3.2
 
 then run::
 

--- a/components/get_data/conda.yml
+++ b/components/get_data/conda.yml
@@ -6,8 +6,7 @@ dependencies:
   - python=3.13.0
   - pip=24.3.1
   - requests=2.31.0
-  - pyarrow=15.0.0
   - pip:
       - mlflow==3.3.2
       - wandb==0.21.3
-      - git+https://github.com/udacity/nd0821-c2-build-model-workflow-starter.git#egg=wandb-utils&subdirectory=components
+      - -e ..

--- a/components/test_regression_model/conda.yml
+++ b/components/test_regression_model/conda.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.13
   - pip=24.3.1
   - requests=2.24.0
-  - scikit-learn=1.3.2
+  - scikit-learn=1.7.2
   - pandas=2.3.2
   - pip:
       - mlflow==3.3.2

--- a/components/test_regression_model/conda.yml
+++ b/components/test_regression_model/conda.yml
@@ -11,4 +11,4 @@ dependencies:
   - pip:
       - mlflow==3.3.2
       - wandb==0.21.3
-      - git+https://github.com/udacity/nd0821-c2-build-model-workflow-starter.git#egg=wandb-utils&subdirectory=components
+      - -e ..

--- a/components/train_val_test_split/conda.yml
+++ b/components/train_val_test_split/conda.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.13
   - pip=24.3.1
   - requests=2.24.0
-  - scikit-learn=1.3.2
+  - scikit-learn=1.7.2
   - pip:
       - mlflow==3.3.2
       - wandb==0.21.3

--- a/components/train_val_test_split/conda.yml
+++ b/components/train_val_test_split/conda.yml
@@ -10,4 +10,4 @@ dependencies:
   - pip:
       - mlflow==3.3.2
       - wandb==0.21.3
-      - git+https://github.com/udacity/nd0821-c2-build-model-workflow-starter.git#egg=wandb-utils&subdirectory=components
+      - -e ..

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 main:
-  components_repository: "https://github.com/udacity/build-ml-pipeline-for-short-term-rental-prices#components"
+  components_repository: "components"
   # All the intermediate files will be copied to this directory at the end of the run.
   # Set this to null if you are running in prod
   project_name: nyc_airbnb

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.13
   - hydra-core=1.3.2
-  - matplotlib=3.10.6
+  - matplotlib=3.10.7
   - pandas=2.3.2
   - jupyterlab=4.4.7
   - cookiecutter=2.6.0

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ _steps = [
 
 
 # This automatically reads in the configuration
-@hydra.main(version_base=None, config_name='config')  # Adding version_base for Python 3.13 compatibility
+@hydra.main(version_base=None, config_name='config', config_path='.')  # Adding version_base for Python 3.13 compatibility
 def go(config: DictConfig):
 
     # Setup the wandb experiment. All runs will be grouped under this name
@@ -40,7 +40,6 @@ def go(config: DictConfig):
             _ = mlflow.run(
                 f"{config['main']['components_repository']}/get_data",
                 "main",
-                version='main',
                 env_manager="conda",
                 parameters={
                     "sample": config["etl"]["sample"],

--- a/src/data_check/conda.yml
+++ b/src/data_check/conda.yml
@@ -5,8 +5,8 @@ channels:
 dependencies:
   - python=3.13
   - pandas=2.3.2
-  - pytest=6.2.2
-  - scipy=1.5.2
+  - pytest=8.4.2
+  - scipy=1.16.1
   - pip=24.3.1
   - pip:
       - mlflow==3.3.2

--- a/src/eda/conda.yml
+++ b/src/eda/conda.yml
@@ -3,13 +3,14 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.13
+  - python=3.12
   - hydra-core=1.3.2
-  - matplotlib=3.10.6
   - pandas=2.3.2
   - pip=24.3.1
-  - scikit-learn=1.3.2
+  - scikit-learn=1.7.2
   - jupyterlab=4.4.7
+  - ydata-profiling=4.17.0
+  - ipywidgets=8.1.7
   - pip:
       - mlflow==3.3.2
       - wandb==0.21.3

--- a/src/train_random_forest/conda.yml
+++ b/src/train_random_forest/conda.yml
@@ -5,10 +5,10 @@ channels:
 dependencies:
   - python=3.13
   - hydra-core=1.3.2
-  - matplotlib=3.10.6
+  - matplotlib=3.10.7
   - pandas=2.3.2
   - pip=24.3.1
-  - scikit-learn=1.3.2
+  - scikit-learn=1.7.2
   - pip:
       - mlflow==3.3.2
       - wandb==0.21.3

--- a/src/train_random_forest/run.py
+++ b/src/train_random_forest/run.py
@@ -53,7 +53,7 @@ def go(args):
 
     ######################################
     # Use run.use_artifact(...).file() to get the train and validation artifact (args.trainval_artifact)
-    # and save the returned path in train_local_pat
+    # and save the returned path in train_local_path
     trainval_local_path = # YOUR CODE HERE
     ######################################
 
@@ -208,7 +208,7 @@ def get_inference_pipeline(rf_config, max_tfidf_features):
     processed_features = ordinal_categorical + non_ordinal_categorical + zero_imputed + ["last_review", "name"]
 
     # Create random forest
-    random_Forest = RandomForestRegressor(**rf_config)
+    random_forest = RandomForestRegressor(**rf_config)
 
     ######################################
     # Create the inference pipeline. The pipeline must have 2 steps: a step called "preprocessor" applying the


### PR DESCRIPTION
This PR provides more updates required to get this project working under Python 3.13. In particular:

1. The `wandb_utils` package now references the local version of the package when cloned and not the one from the original source on the Udacity template. This is so that if any dependencies or packages break when newer versions come out, the student is able to make edits locally and run those instead of having to wait for changes on the Udacity repository.
2. In the EDA step, various versions needed to be changed in order for `ydata_profiling` to work. In particular, Python had to be downgraded to 3.12. `scikit-learn` had to be upgraded to 1.7.2 because 1.5.2 does not work with Python 3.13, and `ydata_profiling` and `ipywidgets` needed to be installed. **Please note**: In the course lesson, the student is instructed to use `profile.to_widgets()`. This is [currently broken and is being tracked](https://stackoverflow.com/questions/79632884/anaconda-to-widget-error-widget-type-not-understood-using-ydata-profiling). The solution for the moment is to replace `to_widgets()` with `to_notebook_iframe()` (i.e. `profile.to_notebook_iframe()`. The content lesson needs to have this line modified ASAP.
3. `scikit-learn` has been upgraded to 1.7.2 wherever it is being used in the pipeline
4. `matplotlib` has been upgraded to 3.10.7 wherever it is being used in the pipeline. The exception is for the EDA step because it for the current version of `ydata_profiling`, `matplotlib` 3.10.7 and even what it is currently set to 3.10.6 does not work. Removing this dependency in the EDA step will install the version designed for `ydata_profiling`. 
5. In the `data_check` step, `pytest` needed to be upgraded to 8.4.2 and `scipy` needed to be upgraded to 1.16.1
6. In the `main.py` file in the parent directory, `config_path='.'` also needed to be specified in the `@hydra.main` call to play nice with Python 3.13.
7. Small typos addressed in `train_random_forest/run.py`.