### PR TITLE
fix: replace invalid reshape usage in TF-IDF preprocessing

### DIFF
--- a/src/train_random_forest/run.py
+++ b/src/train_random_forest/run.py
@@ -182,17 +182,25 @@ def get_inference_pipeline(rf_config, max_tfidf_features):
     )
 
     # Some minimal NLP for the "name" column
-    reshape_to_1d = FunctionTransformer(np.reshape, kw_args={"newshape": -1})
+    reshape_to_1d = FunctionTransformer(
+        lambda x: x.squeeze(),
+        validate=False,
+        feature_names_out="one-to-one",
+    )
     name_tfidf = make_pipeline(
         SimpleImputer(strategy="constant", fill_value=""),
-        reshape_to_1d,
+        FunctionTransformer(
+            lambda x: x.squeeze(),
+            validate=False,
+            feature_names_out="one-to-one",
+        ),
         TfidfVectorizer(
             binary=False,
             max_features=max_tfidf_features,
-            stop_words='english'
+            stop_words="english",
         ),
     )
-
+    
     # Let's put everything together
     preprocessor = ColumnTransformer(
         transformers=[


### PR DESCRIPTION
- Removed deprecated/invalid np.reshape usage with `newshape` argument
- Replaced with FunctionTransformer using `lambda x: x.squeeze()` for proper 1D input
- Ensured compatibility with TfidfVectorizer input requirements
- Standardized string formatting for stop_words argument