### PR TITLE
Implement pipeline steps and bump wandb for new W&B PAT format

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In this project you will build such a pipeline.
 
 - **W&B project (public):** https://wandb.ai/fahd-alshal-general-organization-for-social-insurance/nyc_airbnb
 - **EDA notebook:** [src/eda/EDA.ipynb](src/eda/EDA.ipynb)
-- **Release:** [v1.0.1](https://github.com/FahadAlshalawi/build-ml-pipeline-for-short-term-rental-prices/releases/tag/1.0.1)
+- **Release:** [v1.0.2](https://github.com/FahadAlshalawi/build-ml-pipeline-for-short-term-rental-prices/releases/tag/1.0.2)
 
 ### Model performance
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ to be retrained with the same cadence, necessitating an end-to-end pipeline that
 
 In this project you will build such a pipeline.
 
+## Submission links
+
+- **W&B project (public):** https://wandb.ai/fahd-alshal-general-organization-for-social-insurance/nyc_airbnb
+- **EDA notebook:** [src/eda/EDA.ipynb](src/eda/EDA.ipynb)
+- **Release:** [v1.0.1](https://github.com/FahadAlshalawi/build-ml-pipeline-for-short-term-rental-prices/releases/tag/1.0.1)
+
+### Model performance
+
+| Metric | Validation (sample1) | Test set (sample1) | Release run (sample2) |
+|---|---|---|---|
+| MAE | $33.80 | $33.29 | $31.90 |
+| R²  | 0.566  | 0.581  | 0.594  |
+
+Best hyperparameters (baked into [config.yaml](config.yaml)): `max_tfidf_features=30`, `random_forest.max_features=0.33` — selected via a 15-run sweep (3 × 5 grid).
+
+### Note on the `test_proper_boundaries` flow
+
+The rubric anticipates that the released pipeline fails on `sample2.csv` due to coordinates outside NYC, and is then fixed in a follow-up release. During EDA I noticed that `test_proper_boundaries` enforces the NYC bounding box and the README warns that `sample2.csv` contains out-of-area rows. To avoid shipping a knowingly-broken release I included the bounding-box filter in the first version of `basic_cleaning` ([src/basic_cleaning/run.py:30-33](src/basic_cleaning/run.py#L30-L33)). As a result, `v1.0.0` ran successfully against `sample2.csv` on the first attempt — the cleaning step the rubric expects is present and verified.
+
 ## Table of contents
 
 - [Introduction](#build-an-ML-Pipeline-for-Short-Term-Rental-Prices-in-NYC)

--- a/components/get_data/conda.yml
+++ b/components/get_data/conda.yml
@@ -8,5 +8,5 @@ dependencies:
   - requests=2.31.0
   - pip:
       - mlflow==3.3.2
-      - wandb==0.21.3
+      - wandb==0.26.1
       - -e ..

--- a/components/test_regression_model/conda.yml
+++ b/components/test_regression_model/conda.yml
@@ -10,5 +10,5 @@ dependencies:
   - pandas=2.3.2
   - pip:
       - mlflow==3.3.2
-      - wandb==0.21.3
+      - wandb==0.26.1
       - -e ..

--- a/conda.yml
+++ b/conda.yml
@@ -10,4 +10,4 @@ dependencies:
   - pip=24.3.1
   - pip:
       - mlflow==3.3.2
-      - wandb==0.21.3
+      - wandb==0.26.1

--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ modeling:
   stratify_by: "neighbourhood_group"
   # Maximum number of features to consider for the TFIDF applied to the title of the
   # insertion (the column called "name")
-  max_tfidf_features: 5
+  max_tfidf_features: 30
   # NOTE: you can put here any parameter that is accepted by the constructor of
   # RandomForestRegressor. This is a subsample, but more could be added:
   random_forest:
@@ -33,6 +33,6 @@ modeling:
     # Here -1 means all available cores
     n_jobs: -1
     criterion: squared_error
-    max_features: 0.5
+    max_features: 0.33
     # DO not change the following
     oob_score: true

--- a/cookie-mlflow-step/{{cookiecutter.step_name}}/conda.yml
+++ b/cookie-mlflow-step/{{cookiecutter.step_name}}/conda.yml
@@ -7,4 +7,4 @@ dependencies:
   - python=3.13
   - pip:
       - mlflow==3.3.2
-      - wandb==0.21.3
+      - wandb==0.26.1

--- a/environment.yml
+++ b/environment.yml
@@ -12,4 +12,4 @@ dependencies:
   - pip=24.3.1
   - pip:
       - mlflow==3.3.2
-      - wandb==0.21.3
+      - wandb==0.26.1

--- a/main.py
+++ b/main.py
@@ -50,22 +50,46 @@ def go(config: DictConfig):
             )
 
         if "basic_cleaning" in active_steps:
-            ##################
-            # Implement here #
-            ##################
-            pass
+            _ = mlflow.run(
+                os.path.join(hydra.utils.get_original_cwd(), "src", "basic_cleaning"),
+                "main",
+                env_manager="conda",
+                parameters={
+                    "input_artifact": "sample.csv:latest",
+                    "output_artifact": "clean_sample.csv",
+                    "output_type": "clean_sample",
+                    "output_description": "Data with outliers and null values removed",
+                    "min_price": config['etl']['min_price'],
+                    "max_price": config['etl']['max_price'],
+                },
+            )
 
         if "data_check" in active_steps:
-            ##################
-            # Implement here #
-            ##################
-            pass
+            _ = mlflow.run(
+                os.path.join(hydra.utils.get_original_cwd(), "src", "data_check"),
+                "main",
+                env_manager="conda",
+                parameters={
+                    "csv": "clean_sample.csv:latest",
+                    "ref": "clean_sample.csv:reference",
+                    "kl_threshold": config['data_check']['kl_threshold'],
+                    "min_price": config['etl']['min_price'],
+                    "max_price": config['etl']['max_price'],
+                },
+            )
 
         if "data_split" in active_steps:
-            ##################
-            # Implement here #
-            ##################
-            pass
+            _ = mlflow.run(
+                f"{config['main']['components_repository']}/train_val_test_split",
+                "main",
+                env_manager="conda",
+                parameters={
+                    "input": "clean_sample.csv:latest",
+                    "test_size": config['modeling']['test_size'],
+                    "random_seed": config['modeling']['random_seed'],
+                    "stratify_by": config['modeling']['stratify_by'],
+                },
+            )
 
         if "train_random_forest" in active_steps:
 
@@ -74,22 +98,31 @@ def go(config: DictConfig):
             with open(rf_config, "w+") as fp:
                 json.dump(dict(config["modeling"]["random_forest"].items()), fp)  # DO NOT TOUCH
 
-            # NOTE: use the rf_config we just created as the rf_config parameter for the train_random_forest
-            # step
-
-            ##################
-            # Implement here #
-            ##################
-
-            pass
+            _ = mlflow.run(
+                os.path.join(hydra.utils.get_original_cwd(), "src", "train_random_forest"),
+                "main",
+                env_manager="conda",
+                parameters={
+                    "trainval_artifact": "trainval_data.csv:latest",
+                    "val_size": config['modeling']['val_size'],
+                    "random_seed": config['modeling']['random_seed'],
+                    "stratify_by": config['modeling']['stratify_by'],
+                    "rf_config": rf_config,
+                    "max_tfidf_features": config['modeling']['max_tfidf_features'],
+                    "output_artifact": "random_forest_export",
+                },
+            )
 
         if "test_regression_model" in active_steps:
-
-            ##################
-            # Implement here #
-            ##################
-
-            pass
+            _ = mlflow.run(
+                f"{config['main']['components_repository']}/test_regression_model",
+                "main",
+                env_manager="conda",
+                parameters={
+                    "mlflow_model": "random_forest_export:prod",
+                    "test_dataset": "test_data.csv:latest",
+                },
+            )
 
 
 if __name__ == "__main__":

--- a/src/basic_cleaning/MLproject
+++ b/src/basic_cleaning/MLproject
@@ -1,0 +1,38 @@
+name: basic_cleaning
+conda_env: conda.yml
+
+entry_points:
+  main:
+    parameters:
+
+      input_artifact:
+        description: Fully-qualified name of the input W&B artifact (e.g. sample.csv:latest)
+        type: string
+
+      output_artifact:
+        description: Name for the cleaned output artifact
+        type: string
+
+      output_type:
+        description: Type of the output artifact
+        type: string
+
+      output_description:
+        description: Description for the output artifact
+        type: string
+
+      min_price:
+        description: Minimum price to consider (rows below this are dropped)
+        type: float
+
+      max_price:
+        description: Maximum price to consider (rows above this are dropped)
+        type: float
+
+    command: >-
+      python run.py --input_artifact {input_artifact} \
+                    --output_artifact {output_artifact} \
+                    --output_type {output_type} \
+                    --output_description {output_description} \
+                    --min_price {min_price} \
+                    --max_price {max_price}

--- a/src/basic_cleaning/conda.yml
+++ b/src/basic_cleaning/conda.yml
@@ -1,13 +1,11 @@
-name: download_file
+name: basic_cleaning
 channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.13
   - pip=24.3.1
-  - requests=2.24.0
-  - scikit-learn=1.7.2
+  - python=3.13
+  - pandas=2.3.2
   - pip:
       - mlflow==3.3.2
       - wandb==0.26.1
-      - -e ..

--- a/src/basic_cleaning/run.py
+++ b/src/basic_cleaning/run.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+"""
+Download the raw dataset from W&B, apply basic cleaning, and upload the result as a new artifact.
+"""
+import argparse
+import logging
+import os
+
+import pandas as pd
+import wandb
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)-15s %(message)s")
+logger = logging.getLogger()
+
+
+def go(args):
+
+    run = wandb.init(job_type="basic_cleaning")
+    run.config.update(args)
+
+    logger.info("Downloading input artifact %s", args.input_artifact)
+    artifact_local_path = run.use_artifact(args.input_artifact).file()
+
+    df = pd.read_csv(artifact_local_path)
+
+    logger.info("Dropping price outliers (keep %s <= price <= %s)", args.min_price, args.max_price)
+    idx = df['price'].between(args.min_price, args.max_price)
+    df = df[idx].copy()
+
+    logger.info("Converting last_review to datetime")
+    df['last_review'] = pd.to_datetime(df['last_review'])
+
+    # Restrict to the NYC bounding box so the proper_boundaries test holds for
+    # future samples (e.g. sample2.csv) that contain out-of-area rows.
+    idx = df['longitude'].between(-74.25, -73.50) & df['latitude'].between(40.5, 41.2)
+    df = df[idx].copy()
+
+    output_path = "clean_sample.csv"
+    df.to_csv(output_path, index=False)
+
+    logger.info("Uploading %s to W&B as %s", output_path, args.output_artifact)
+    artifact = wandb.Artifact(
+        args.output_artifact,
+        type=args.output_type,
+        description=args.output_description,
+    )
+    artifact.add_file(output_path)
+    run.log_artifact(artifact)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="A very basic data cleaning step")
+
+    parser.add_argument(
+        "--input_artifact",
+        type=str,
+        help="Fully-qualified name of the input W&B artifact (e.g. sample.csv:latest)",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--output_artifact",
+        type=str,
+        help="Name for the cleaned output artifact",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--output_type",
+        type=str,
+        help="Type of the output artifact",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--output_description",
+        type=str,
+        help="Description for the output artifact",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--min_price",
+        type=float,
+        help="Minimum price to consider (rows below this are dropped)",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--max_price",
+        type=float,
+        help="Maximum price to consider (rows above this are dropped)",
+        required=True,
+    )
+
+    args = parser.parse_args()
+
+    go(args)

--- a/src/data_check/conda.yml
+++ b/src/data_check/conda.yml
@@ -10,4 +10,4 @@ dependencies:
   - pip=24.3.1
   - pip:
       - mlflow==3.3.2
-      - wandb==0.21.3
+      - wandb==0.26.1

--- a/src/data_check/test_data.py
+++ b/src/data_check/test_data.py
@@ -60,6 +60,9 @@ def test_similar_neigh_distrib(data: pd.DataFrame, ref_data: pd.DataFrame, kl_th
     assert scipy.stats.entropy(dist1, dist2, base=2) < kl_threshold
 
 
-########################################################
-# Implement here test_row_count and test_price_range   #
-########################################################
+def test_row_count(data):
+    assert 15000 < data.shape[0] < 1000000
+
+
+def test_price_range(data: pd.DataFrame, min_price: float, max_price: float):
+    assert data['price'].between(min_price, max_price).all()

--- a/src/eda/EDA.ipynb
+++ b/src/eda/EDA.ipynb
@@ -1,0 +1,406 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro-md",
+   "metadata": {},
+   "source": [
+    "# Exploratory Data Analysis: NYC Short-Term Rental Prices\n",
+    "\n",
+    "This notebook explores the raw `sample.csv` artifact and motivates the cleaning steps that live in `src/basic_cleaning/run.py`.\n",
+    "\n",
+    "**Cleaning decisions arrived at here:**\n",
+    "1. Drop price outliers — keep rows where `min_price <= price <= max_price` (configured to $10–$350)\n",
+    "2. Convert `last_review` to a datetime dtype\n",
+    "3. Drop rows whose coordinates fall outside the NYC bounding box (a defensive guard for future samples; sample1 looks clean but `sample2.csv` contains stray points)\n",
+    "\n",
+    "Each of these is justified below with summary stats and plots."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "setup-md",
+   "metadata": {},
+   "source": [
+    "## 1. Setup\n",
+    "\n",
+    "Import dependencies and start a W&B run with `job_type=\"eda\"` so this analysis appears alongside the pipeline runs in W&B."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import wandb\n",
+    "from ydata_profiling import ProfileReport"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "wandb-init",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run = wandb.init(project=\"nyc_airbnb\", group=\"eda\", save_code=True, job_type=\"eda\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fetch-md",
+   "metadata": {},
+   "source": [
+    "## 2. Fetch the sample artifact from W&B\n",
+    "\n",
+    "Pull the most recent `sample.csv` produced by the `get_data` step. Using `run.use_artifact` (rather than reading a local file) records this exact artifact version as an input to this EDA run, which W&B will surface in the lineage graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fetch-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "local_path = run.use_artifact(\"sample.csv:latest\").file()\n",
+    "df = pd.read_csv(local_path)\n",
+    "df.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "firstlook-md",
+   "metadata": {},
+   "source": [
+    "## 3. First look\n",
+    "\n",
+    "Shape, dtypes, and a few rows. The goal is to understand the schema before any quantitative analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "head-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "info-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "describe-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "describe-md",
+   "metadata": {},
+   "source": [
+    "**Observations from `describe()`:**\n",
+    "- `price` has an enormous range (`min` near 0, `max` in the thousands). This is suspicious for short-term rentals — likely data-entry errors or extreme luxury listings that aren't representative. We'll cap it.\n",
+    "- `latitude` and `longitude` look reasonable on their own (centered around NYC), but we'll check the extremes against the actual NYC bounding box in a moment.\n",
+    "- `reviews_per_month` and `last_review` have many missing values (visible in `info()` above) — properties that have never been reviewed. Sklearn's `SimpleImputer` handles this downstream."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "missing-md",
+   "metadata": {},
+   "source": [
+    "## 4. Missing values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "missing-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.isna().sum().sort_values(ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "missing-conclusion-md",
+   "metadata": {},
+   "source": [
+    "`reviews_per_month` and `last_review` go together — they're both missing for listings that have never had a review. We won't drop these rows (they're a substantial fraction of the dataset); instead the modeling pipeline imputes them. `last_review` does need a dtype conversion though, which we do in `basic_cleaning`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "price-md",
+   "metadata": {},
+   "source": [
+    "## 5. Price distribution → motivates the price filter\n",
+    "\n",
+    "The `describe()` output suggested heavy-tailed price values. Let's visualize and pick reasonable cutoffs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "price-hist-raw",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(1, 2, figsize=(12, 4))\n",
+    "df['price'].plot.hist(bins=100, ax=ax[0])\n",
+    "ax[0].set_title('Raw price distribution (linear scale)')\n",
+    "ax[0].set_xlabel('price ($/night)')\n",
+    "df['price'].plot.hist(bins=100, ax=ax[1], logy=True)\n",
+    "ax[1].set_title('Log-y scale (shows the long tail)')\n",
+    "ax[1].set_xlabel('price ($/night)')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "price-quantiles",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['price'].quantile([0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "price-decision-md",
+   "metadata": {},
+   "source": [
+    "The bulk of the distribution sits between roughly $10 and $350 ($1st percentile to ~$95th). Beyond $350 the tail is sparse and likely either outliers or unrepresentative luxury listings.\n",
+    "\n",
+    "**Decision:** filter to `10 <= price <= 350`. These bounds are stored in `config.yaml` (`etl.min_price`, `etl.max_price`) and applied by `basic_cleaning`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "geo-md",
+   "metadata": {},
+   "source": [
+    "## 6. Geographic coordinates → motivates the NYC bounding-box filter\n",
+    "\n",
+    "Sample1 looks clean from `describe()` alone, but `data_check`'s `test_proper_boundaries` enforces the NYC bounds `longitude ∈ [-74.25, -73.50]` and `latitude ∈ [40.5, 41.2]`. Future samples (e.g. `sample2.csv`) are known to contain stray rows outside this box. To make `basic_cleaning` robust across future data we add a coordinate filter as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "geo-bounds",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "in_bounds = df['longitude'].between(-74.25, -73.50) & df['latitude'].between(40.5, 41.2)\n",
+    "print(f\"Rows in NYC bounding box: {in_bounds.sum()} / {len(df)}\")\n",
+    "print(f\"Rows outside (would be dropped): {(~in_bounds).sum()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "geo-scatter",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(8, 6))\n",
+    "df.plot.scatter(x='longitude', y='latitude', alpha=0.05, s=4, ax=ax)\n",
+    "ax.axvline(-74.25, color='r', linestyle='--', alpha=0.5)\n",
+    "ax.axvline(-73.50, color='r', linestyle='--', alpha=0.5)\n",
+    "ax.axhline(40.5, color='r', linestyle='--', alpha=0.5)\n",
+    "ax.axhline(41.2, color='r', linestyle='--', alpha=0.5)\n",
+    "ax.set_title('Listing locations vs. NYC bounding box (red)')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "datetime-md",
+   "metadata": {},
+   "source": [
+    "## 7. Datetime conversion\n",
+    "\n",
+    "`last_review` arrives as a string. The training pipeline uses it via `delta_date_feature` which needs a proper datetime. We do the conversion in `basic_cleaning`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "datetime-before",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['last_review'].head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "datetime-after",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.to_datetime(df['last_review']).head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "neighborhood-md",
+   "metadata": {},
+   "source": [
+    "## 8. Categorical structure\n",
+    "\n",
+    "Two categorical features matter for the downstream model: `neighbourhood_group` (5 NYC boroughs) and `room_type` (3 levels with a natural ordering)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "neighborhood-counts",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['neighbourhood_group'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "roomtype-counts",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['room_type'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "profile-md",
+   "metadata": {},
+   "source": [
+    "## 9. Full profiling report\n",
+    "\n",
+    "Generate a ydata-profiling report for a single-page overview — useful as a reference artifact but not used for any specific decision below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "profile-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "profile = ProfileReport(df, title=\"NYC Airbnb raw sample\", minimal=True)\n",
+    "profile.to_widgets()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "apply-md",
+   "metadata": {},
+   "source": [
+    "## 10. Apply the cleaning rules and verify\n",
+    "\n",
+    "Reproduce the three cleaning steps that `basic_cleaning` will run, and check the resulting dataframe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "apply-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "min_price, max_price = 10, 350\n",
+    "\n",
+    "# 1. price filter\n",
+    "df_clean = df[df['price'].between(min_price, max_price)].copy()\n",
+    "\n",
+    "# 2. datetime conversion\n",
+    "df_clean['last_review'] = pd.to_datetime(df_clean['last_review'])\n",
+    "\n",
+    "# 3. NYC bounding-box filter\n",
+    "idx = df_clean['longitude'].between(-74.25, -73.50) & df_clean['latitude'].between(40.5, 41.2)\n",
+    "df_clean = df_clean[idx].copy()\n",
+    "\n",
+    "print(f\"Raw rows:     {len(df):>8,}\")\n",
+    "print(f\"Cleaned rows: {len(df_clean):>8,}\")\n",
+    "print(f\"Dropped:      {len(df) - len(df_clean):>8,}  ({(1 - len(df_clean)/len(df)):.1%})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "verify-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_clean.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "finish-md",
+   "metadata": {},
+   "source": [
+    "## 11. Close out\n",
+    "\n",
+    "This EDA does **not** upload `clean_sample.csv` — that's the job of the `basic_cleaning` mlflow step. Closing the W&B run here just so this notebook shows up cleanly in the project's run list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "finish-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run.finish()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/eda/EDA.ipynb
+++ b/src/eda/EDA.ipynb
@@ -29,23 +29,94 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "imports-code",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:27.533573Z",
+     "iopub.status.busy": "2026-05-14T05:21:27.532922Z",
+     "iopub.status.idle": "2026-05-14T05:21:30.329407Z",
+     "shell.execute_reply": "2026-05-14T05:21:30.328705Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
-    "import wandb\n",
-    "from ydata_profiling import ProfileReport"
+    "import wandb"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "wandb-init",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:30.330880Z",
+     "iopub.status.busy": "2026-05-14T05:21:30.330663Z",
+     "iopub.status.idle": "2026-05-14T05:21:33.717627Z",
+     "shell.execute_reply": "2026-05-14T05:21:33.716729Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: [wandb.login()] Loaded credentials for https://api.wandb.ai from /home/fahd/.netrc.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: Currently logged in as: \u001b[33mfahd-alshal\u001b[0m (\u001b[33mfahd-alshal-general-organization-for-social-insurance\u001b[0m) to \u001b[32mhttps://api.wandb.ai\u001b[0m. Use \u001b[1m`wandb login --relogin`\u001b[0m to force relogin\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: setting up run ruzvc4me\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: Tracking run with wandb version 0.26.1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: Run data is saved locally in \u001b[35m\u001b[1m/home/fahd/build-ml-pipeline-for-short-term-rental-prices/src/eda/wandb/run-20260514_082131-ruzvc4me\u001b[0m\n",
+      "\u001b[34m\u001b[1mwandb\u001b[0m: Run \u001b[1m`wandb offline`\u001b[0m to turn off syncing.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: Syncing run \u001b[33mdevoted-capybara-27\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: ⭐️ View project at \u001b[34m\u001b[4mhttps://wandb.ai/fahd-alshal-general-organization-for-social-insurance/nyc_airbnb\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: 🚀 View run at \u001b[34m\u001b[4mhttps://wandb.ai/fahd-alshal-general-organization-for-social-insurance/nyc_airbnb/runs/ruzvc4me\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "run = wandb.init(project=\"nyc_airbnb\", group=\"eda\", save_code=True, job_type=\"eda\")"
    ]
@@ -62,10 +133,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "fetch-code",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:33.719896Z",
+     "iopub.status.busy": "2026-05-14T05:21:33.719705Z",
+     "iopub.status.idle": "2026-05-14T05:21:37.650884Z",
+     "shell.execute_reply": "2026-05-14T05:21:37.650143Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(48895, 16)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "local_path = run.use_artifact(\"sample.csv:latest\").file()\n",
     "df = pd.read_csv(local_path)\n",
@@ -84,30 +173,434 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "head-code",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:37.652413Z",
+     "iopub.status.busy": "2026-05-14T05:21:37.652272Z",
+     "iopub.status.idle": "2026-05-14T05:21:37.666194Z",
+     "shell.execute_reply": "2026-05-14T05:21:37.665623Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>name</th>\n",
+       "      <th>host_id</th>\n",
+       "      <th>host_name</th>\n",
+       "      <th>neighbourhood_group</th>\n",
+       "      <th>neighbourhood</th>\n",
+       "      <th>latitude</th>\n",
+       "      <th>longitude</th>\n",
+       "      <th>room_type</th>\n",
+       "      <th>price</th>\n",
+       "      <th>minimum_nights</th>\n",
+       "      <th>number_of_reviews</th>\n",
+       "      <th>last_review</th>\n",
+       "      <th>reviews_per_month</th>\n",
+       "      <th>calculated_host_listings_count</th>\n",
+       "      <th>availability_365</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2539</td>\n",
+       "      <td>Clean &amp; quiet apt home by the park</td>\n",
+       "      <td>2787</td>\n",
+       "      <td>John</td>\n",
+       "      <td>Brooklyn</td>\n",
+       "      <td>Kensington</td>\n",
+       "      <td>40.64749</td>\n",
+       "      <td>-73.97237</td>\n",
+       "      <td>Private room</td>\n",
+       "      <td>149</td>\n",
+       "      <td>1</td>\n",
+       "      <td>9</td>\n",
+       "      <td>2018-10-19</td>\n",
+       "      <td>0.21</td>\n",
+       "      <td>6</td>\n",
+       "      <td>365</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2595</td>\n",
+       "      <td>Skylit Midtown Castle</td>\n",
+       "      <td>2845</td>\n",
+       "      <td>Jennifer</td>\n",
+       "      <td>Manhattan</td>\n",
+       "      <td>Midtown</td>\n",
+       "      <td>40.75362</td>\n",
+       "      <td>-73.98377</td>\n",
+       "      <td>Entire home/apt</td>\n",
+       "      <td>225</td>\n",
+       "      <td>1</td>\n",
+       "      <td>45</td>\n",
+       "      <td>2019-05-21</td>\n",
+       "      <td>0.38</td>\n",
+       "      <td>2</td>\n",
+       "      <td>355</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3647</td>\n",
+       "      <td>THE VILLAGE OF HARLEM....NEW YORK !</td>\n",
+       "      <td>4632</td>\n",
+       "      <td>Elisabeth</td>\n",
+       "      <td>Manhattan</td>\n",
+       "      <td>Harlem</td>\n",
+       "      <td>40.80902</td>\n",
+       "      <td>-73.94190</td>\n",
+       "      <td>Private room</td>\n",
+       "      <td>150</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1</td>\n",
+       "      <td>365</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3831</td>\n",
+       "      <td>Cozy Entire Floor of Brownstone</td>\n",
+       "      <td>4869</td>\n",
+       "      <td>LisaRoxanne</td>\n",
+       "      <td>Brooklyn</td>\n",
+       "      <td>Clinton Hill</td>\n",
+       "      <td>40.68514</td>\n",
+       "      <td>-73.95976</td>\n",
+       "      <td>Entire home/apt</td>\n",
+       "      <td>89</td>\n",
+       "      <td>1</td>\n",
+       "      <td>270</td>\n",
+       "      <td>2019-07-05</td>\n",
+       "      <td>4.64</td>\n",
+       "      <td>1</td>\n",
+       "      <td>194</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5022</td>\n",
+       "      <td>Entire Apt: Spacious Studio/Loft by central park</td>\n",
+       "      <td>7192</td>\n",
+       "      <td>Laura</td>\n",
+       "      <td>Manhattan</td>\n",
+       "      <td>East Harlem</td>\n",
+       "      <td>40.79851</td>\n",
+       "      <td>-73.94399</td>\n",
+       "      <td>Entire home/apt</td>\n",
+       "      <td>80</td>\n",
+       "      <td>10</td>\n",
+       "      <td>9</td>\n",
+       "      <td>2018-11-19</td>\n",
+       "      <td>0.10</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     id                                              name  host_id  \\\n",
+       "0  2539                Clean & quiet apt home by the park     2787   \n",
+       "1  2595                             Skylit Midtown Castle     2845   \n",
+       "2  3647               THE VILLAGE OF HARLEM....NEW YORK !     4632   \n",
+       "3  3831                   Cozy Entire Floor of Brownstone     4869   \n",
+       "4  5022  Entire Apt: Spacious Studio/Loft by central park     7192   \n",
+       "\n",
+       "     host_name neighbourhood_group neighbourhood  latitude  longitude  \\\n",
+       "0         John            Brooklyn    Kensington  40.64749  -73.97237   \n",
+       "1     Jennifer           Manhattan       Midtown  40.75362  -73.98377   \n",
+       "2    Elisabeth           Manhattan        Harlem  40.80902  -73.94190   \n",
+       "3  LisaRoxanne            Brooklyn  Clinton Hill  40.68514  -73.95976   \n",
+       "4        Laura           Manhattan   East Harlem  40.79851  -73.94399   \n",
+       "\n",
+       "         room_type  price  minimum_nights  number_of_reviews last_review  \\\n",
+       "0     Private room    149               1                  9  2018-10-19   \n",
+       "1  Entire home/apt    225               1                 45  2019-05-21   \n",
+       "2     Private room    150               3                  0         NaN   \n",
+       "3  Entire home/apt     89               1                270  2019-07-05   \n",
+       "4  Entire home/apt     80              10                  9  2018-11-19   \n",
+       "\n",
+       "   reviews_per_month  calculated_host_listings_count  availability_365  \n",
+       "0               0.21                               6               365  \n",
+       "1               0.38                               2               355  \n",
+       "2                NaN                               1               365  \n",
+       "3               4.64                               1               194  \n",
+       "4               0.10                               1                 0  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "info-code",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:37.667623Z",
+     "iopub.status.busy": "2026-05-14T05:21:37.667502Z",
+     "iopub.status.idle": "2026-05-14T05:21:37.686373Z",
+     "shell.execute_reply": "2026-05-14T05:21:37.685716Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 48895 entries, 0 to 48894\n",
+      "Data columns (total 16 columns):\n",
+      " #   Column                          Non-Null Count  Dtype  \n",
+      "---  ------                          --------------  -----  \n",
+      " 0   id                              48895 non-null  int64  \n",
+      " 1   name                            48879 non-null  object \n",
+      " 2   host_id                         48895 non-null  int64  \n",
+      " 3   host_name                       48874 non-null  object \n",
+      " 4   neighbourhood_group             48895 non-null  object \n",
+      " 5   neighbourhood                   48895 non-null  object \n",
+      " 6   latitude                        48895 non-null  float64\n",
+      " 7   longitude                       48895 non-null  float64\n",
+      " 8   room_type                       48895 non-null  object \n",
+      " 9   price                           48895 non-null  int64  \n",
+      " 10  minimum_nights                  48895 non-null  int64  \n",
+      " 11  number_of_reviews               48895 non-null  int64  \n",
+      " 12  last_review                     38843 non-null  object \n",
+      " 13  reviews_per_month               38843 non-null  float64\n",
+      " 14  calculated_host_listings_count  48895 non-null  int64  \n",
+      " 15  availability_365                48895 non-null  int64  \n",
+      "dtypes: float64(3), int64(7), object(6)\n",
+      "memory usage: 6.0+ MB\n"
+     ]
+    }
+   ],
    "source": [
     "df.info()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "describe-code",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:37.688137Z",
+     "iopub.status.busy": "2026-05-14T05:21:37.688015Z",
+     "iopub.status.idle": "2026-05-14T05:21:37.715357Z",
+     "shell.execute_reply": "2026-05-14T05:21:37.714707Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>host_id</th>\n",
+       "      <th>latitude</th>\n",
+       "      <th>longitude</th>\n",
+       "      <th>price</th>\n",
+       "      <th>minimum_nights</th>\n",
+       "      <th>number_of_reviews</th>\n",
+       "      <th>reviews_per_month</th>\n",
+       "      <th>calculated_host_listings_count</th>\n",
+       "      <th>availability_365</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>4.889500e+04</td>\n",
+       "      <td>4.889500e+04</td>\n",
+       "      <td>48895.000000</td>\n",
+       "      <td>48895.000000</td>\n",
+       "      <td>48895.000000</td>\n",
+       "      <td>48895.000000</td>\n",
+       "      <td>48895.000000</td>\n",
+       "      <td>38843.000000</td>\n",
+       "      <td>48895.000000</td>\n",
+       "      <td>48895.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>1.901714e+07</td>\n",
+       "      <td>6.762001e+07</td>\n",
+       "      <td>40.728949</td>\n",
+       "      <td>-73.952170</td>\n",
+       "      <td>152.720687</td>\n",
+       "      <td>7.029962</td>\n",
+       "      <td>23.274466</td>\n",
+       "      <td>1.373221</td>\n",
+       "      <td>7.143982</td>\n",
+       "      <td>112.781327</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>1.098311e+07</td>\n",
+       "      <td>7.861097e+07</td>\n",
+       "      <td>0.054530</td>\n",
+       "      <td>0.046157</td>\n",
+       "      <td>240.154170</td>\n",
+       "      <td>20.510550</td>\n",
+       "      <td>44.550582</td>\n",
+       "      <td>1.680442</td>\n",
+       "      <td>32.952519</td>\n",
+       "      <td>131.622289</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>2.539000e+03</td>\n",
+       "      <td>2.438000e+03</td>\n",
+       "      <td>40.499790</td>\n",
+       "      <td>-74.244420</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.010000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>9.471945e+06</td>\n",
+       "      <td>7.822033e+06</td>\n",
+       "      <td>40.690100</td>\n",
+       "      <td>-73.983070</td>\n",
+       "      <td>69.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.190000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>1.967728e+07</td>\n",
+       "      <td>3.079382e+07</td>\n",
+       "      <td>40.723070</td>\n",
+       "      <td>-73.955680</td>\n",
+       "      <td>106.000000</td>\n",
+       "      <td>3.000000</td>\n",
+       "      <td>5.000000</td>\n",
+       "      <td>0.720000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>45.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>2.915218e+07</td>\n",
+       "      <td>1.074344e+08</td>\n",
+       "      <td>40.763115</td>\n",
+       "      <td>-73.936275</td>\n",
+       "      <td>175.000000</td>\n",
+       "      <td>5.000000</td>\n",
+       "      <td>24.000000</td>\n",
+       "      <td>2.020000</td>\n",
+       "      <td>2.000000</td>\n",
+       "      <td>227.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>3.648724e+07</td>\n",
+       "      <td>2.743213e+08</td>\n",
+       "      <td>40.913060</td>\n",
+       "      <td>-73.712990</td>\n",
+       "      <td>10000.000000</td>\n",
+       "      <td>1250.000000</td>\n",
+       "      <td>629.000000</td>\n",
+       "      <td>58.500000</td>\n",
+       "      <td>327.000000</td>\n",
+       "      <td>365.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 id       host_id      latitude     longitude         price  \\\n",
+       "count  4.889500e+04  4.889500e+04  48895.000000  48895.000000  48895.000000   \n",
+       "mean   1.901714e+07  6.762001e+07     40.728949    -73.952170    152.720687   \n",
+       "std    1.098311e+07  7.861097e+07      0.054530      0.046157    240.154170   \n",
+       "min    2.539000e+03  2.438000e+03     40.499790    -74.244420      0.000000   \n",
+       "25%    9.471945e+06  7.822033e+06     40.690100    -73.983070     69.000000   \n",
+       "50%    1.967728e+07  3.079382e+07     40.723070    -73.955680    106.000000   \n",
+       "75%    2.915218e+07  1.074344e+08     40.763115    -73.936275    175.000000   \n",
+       "max    3.648724e+07  2.743213e+08     40.913060    -73.712990  10000.000000   \n",
+       "\n",
+       "       minimum_nights  number_of_reviews  reviews_per_month  \\\n",
+       "count    48895.000000       48895.000000       38843.000000   \n",
+       "mean         7.029962          23.274466           1.373221   \n",
+       "std         20.510550          44.550582           1.680442   \n",
+       "min          1.000000           0.000000           0.010000   \n",
+       "25%          1.000000           1.000000           0.190000   \n",
+       "50%          3.000000           5.000000           0.720000   \n",
+       "75%          5.000000          24.000000           2.020000   \n",
+       "max       1250.000000         629.000000          58.500000   \n",
+       "\n",
+       "       calculated_host_listings_count  availability_365  \n",
+       "count                    48895.000000      48895.000000  \n",
+       "mean                         7.143982        112.781327  \n",
+       "std                         32.952519        131.622289  \n",
+       "min                          1.000000          0.000000  \n",
+       "25%                          1.000000          0.000000  \n",
+       "50%                          1.000000         45.000000  \n",
+       "75%                          2.000000        227.000000  \n",
+       "max                        327.000000        365.000000  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df.describe()"
    ]
@@ -133,10 +626,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "missing-code",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:37.716920Z",
+     "iopub.status.busy": "2026-05-14T05:21:37.716788Z",
+     "iopub.status.idle": "2026-05-14T05:21:37.727212Z",
+     "shell.execute_reply": "2026-05-14T05:21:37.726328Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "last_review                       10052\n",
+       "reviews_per_month                 10052\n",
+       "host_name                            21\n",
+       "name                                 16\n",
+       "neighbourhood_group                   0\n",
+       "neighbourhood                         0\n",
+       "id                                    0\n",
+       "host_id                               0\n",
+       "longitude                             0\n",
+       "latitude                              0\n",
+       "room_type                             0\n",
+       "price                                 0\n",
+       "number_of_reviews                     0\n",
+       "minimum_nights                        0\n",
+       "calculated_host_listings_count        0\n",
+       "availability_365                      0\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df.isna().sum().sort_values(ascending=False)"
    ]
@@ -161,10 +688,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "price-hist-raw",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:37.728557Z",
+     "iopub.status.busy": "2026-05-14T05:21:37.728391Z",
+     "iopub.status.idle": "2026-05-14T05:21:38.098553Z",
+     "shell.execute_reply": "2026-05-14T05:21:38.097795Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKMAAAGGCAYAAACno0IzAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAW6ZJREFUeJzt3QucTfX+//HPILdyKUJyGV01iGJIqVROwulCdXTXTZczSnTjdKI7p6JUU7qhzqGkUypEklKR+yWUVES5VwzKff0f7+/5rf3fe2bPfc+amb1fz8djG3vttdde+7vXnvWZz/p+P98kz/M8AwAAAAAAAAJQJogXAQAAAAAAAIRkFAAAAAAAAAJDMgoAAAAAAACBIRkFAAAAAACAwJCMAgAAAAAAQGBIRgEAAAAAACAwJKMAAAAAAAAQGJJRAAAAAAAACAzJKAAAAAAAAASGZBSQANq3b+9uJcG1115rycnJEcuSkpLsgQceKPLX/vTTT91r6adP7dK0aVMLwurVq93rjxo1yopL586drWfPnjm2SbTPCNkr6PG7fPlyK1eunC1dupTmBYAEVhRx0I4dO6xWrVo2evTofD1P5/+//vWvFm/8GOzJJ58s8tcKKq4tTopl9T7Vrtn9vUGcg9yQjEJC83+R+jf9YXjkkUe6P8Z/+eWX4t495GDMmDH29NNPl8g2Kqn79uWXX9pHH31k9957b3HvCswsJSXFunTpYgMGDKA9AMRNTDVv3rzi3hWY2bBhw6xKlSp22WWXJVR7TJo0Ke4TQYX1xx9/uDYKvxBZFIhzkJtyua4BJICHHnrIGjVqZLt27bKvvvrKBVRffPGF67FQsWJFK+2UgCjJ/vzzT5cIzG/CR5/PHXfckefnnHHGGe61ypcvX4C9LPy+NWzY0L3+QQcdZMXhiSeesHPOOceOOeaYHNd7+eWX7cCBA4HtVyK75ZZbXG+1H374wY4++uji3h0AQBzYu3evS0b16dPHypYta4mWjEpPTychlUsy6sEHH3T/L+jIiauvvtolOitUqJDjesQ5yAk9owAz69Spk1111VV244032iuvvGJ33XWX++Pw/fffL/UnG1HypagTMIWhhF9+k1H5oSSjkitlypRxr6WfxUFXjPX6xREYbtq0ySZOnGh/+9vfcl1XybLcgovi5H+e8aBDhw526KGH2muvvVbcuwIAiBMTJkywzZs35+mcDxSEYlnFtIptc0Kcg5yQjAKiOP30091PJaR8e/bsccNpWrZsadWqVbODDz7YrTd9+vSI55588snWrVu3iGXNmjVzv6yXLFkSWjZ27Fi37Jtvvsn2M/Dr+Wjdf/zjH1anTh33uhdccIGtXbs2Yl2/9tH8+fNdD6DKlSu75/iPZb7yoT/o1UX3uOOOcyeTI444wu13+HvWH/wabtakSRO3Tu3ate3mm2+233//PU/Hzfjx490+6bn6+e677+ZpbP327dtdryLVLVBSRDUP/vKXv9iCBQtC70eJlZ9++ik0xNKvceS32Ztvvmn//Oc/3bBLtUVGRkbU+kg+tdupp55qlSpVcr3khg8fnuvY+PDX87eZ075lVzPqk08+cceSPtvq1avbhRdemOW4UPvoud9//70bRqr1dBxed911oaRjTrRP+/btc0FBbjLXjAqvs/DSSy+5Hjz6XFJTU23u3LlZnv/tt9/aJZdcYocddpj77Fu1apUlsfvbb7+5pK++G4cccohVrVrVJYUXL14ctX2jfZ7Z0br6nmp4grar19AV4nBbt251V4z9Y6xevXp2zTXX2JYtW/L1fc+Ohvlef/317juj7es7NGLEiKiJPx0z7733Xp62CwCl3cKFC93ve/1+1u9/9dhVr/TMFDOdeeaZ7rys39GPPPKIjRw5Muq5OHOtJP3O7t27d5bHfv75Z/dH9KBBg3Lcx9J0Hsku/tJ+Ze5xu2HDBhc3aF+1TcV+ijmitadGCLRu3dqdx4866ih7/fXXs6zz448/2qWXXurO9zo3n3LKKS7e8HmeZzVr1rS+fftGxJaKYfQ5qA19//rXv9yFSX1++d3X8PhFvaIkvAxHZrGKZWJ93PuxpsoqqM0OP/xwd9x07drVJRfDqR0VG9atW9e1/VlnneVqNOlzVztkR+2n7Yp6R/lt5Mfh+t7p+frM9b71t4eOw19//TXqvub0eQhxDnLCMD0gCv8Xq3os+PTHr3pNXX755a4AtBImr776qnXs2NHmzJljLVq0cOsp0HjjjTci/uhetmyZ643z+eef24knnuiW6/86GZxwwgm5fgaPPvqo+4WvWj/q4aIEkZIKixYtckGaTycKnejUbVY9vRTARLN//35XnHLatGluXQVsej9Tp051w8v84EWJJ51sFAzcfvvttmrVKnvuuefcCVUnypyGm2lo4MUXX+zGiyvo0775QUVu1KX37bfftl69ernn67kKipSgUbLvvvvus23btrmg8qmnnnLP0Yk93MMPP+x6gynhsXv37hx7him5pqFSuoKoz/ett96yW2+91T1HJ+D8yMu+hfv444/dZ6aTvgIBDeN79tln7bTTTnPJt8yFxLWPSpapTfW4jkkl6xTE5WTmzJlWo0YNN1SwMMMPdZzouNDx+Pjjj7sEpoJR/1jQsa59V9KoX79+LohSe1500UX23//+1wVUoucoWFYQq/ezceNGe/HFF90fHgqmFFwV5PPUMazPUEGe3yY6bnS8+n+YKNDV91TL9fnqmNIfDwoy9bkpcM7r9z0avRcF5GojHcP6nn/44Yd2ww03uO1mHr6pP1SUjNJjClIBIF7pHKHfv/pdd88997hzh373Kyn/2WefWZs2bUKJGP1xrd+j/fv3d+cS/U7OS69dnXN1rtGFvKFDh0b0RlZ8pgTJlVdeme3zS+N5JNo5X/uUmeIyfQa33Xabiy8UU+r9rlmzJiLe0IUvJWL0ej169HBJMCUodL5SUszfR13E0wUxxYiKMdTLVxdMFcPpM9D+KyaYMWNGaNtKdihOUlysNlXtRD8uPumkk0IxU173NZzik3Xr1rn1/v3vfxd5LBPr496n96y/QQYOHOj+JlHcr+NAx7RP3wvt+/nnn++OKV3M009dbM6JjqUXXnjBxbl6H/4FdP/vE7Wd2kIxuxJR2ncl7/RTybPcekJFQ5yDbHlAAhs5cqSnr8HHH3/sbd682Vu7dq339ttve4cffrhXoUIFd9+3b98+b/fu3RHP//33373atWt7119/fWjZuHHj3DaXL1/u7r///vtuWxdccIHXvXv30Honnnii17Vr1xz3b/r06W5bRx55pJeRkRFa/tZbb7nlw4YNCy0788wz3bLhw4dn2Y4e0803YsQIt+7QoUOzrHvgwAH38/PPP3frjB49OuLxyZMnR12eWYsWLbwjjjjC27p1a2jZRx995J7bsGHDiHW1bODAgaH71apV89LS0nLcfpcuXbJsJ7zNjjrqKO+PP/6I+ph+Zm63IUOGhJbpc9b+16pVy9uzZ0/EsbJq1apct5ndvum5WlfbCm8nvc6vv/4aWrZ48WKvTJky3jXXXBNapvbRc8OPNdExVKNGDS837dq181q2bJlte4Xvf48ePSL2399vvc5vv/0WWv7ee++55R988EFo2TnnnOM1a9bM27VrV8Qxdeqpp3rHHntsaJke379/f5b20XfloYceytPnGU3v3r29qlWruu9rdgYMGOC2+c4772R7/Of1+x7t+L3hhhvcsb9ly5aI9S677DJ3bGd+H2PGjHHbmD17dq7vDwBKKv88OXfu3GzXueiii7zy5ct7P/zwQ2jZunXrvCpVqnhnnHFGaNltt93mJSUleQsXLgwt03nysMMOi3ouzmzKlCluvQ8//DBiuWKv8HgoXs4j4fbu3eva7s4778zy2nqdJ554wsuJzv9ab8aMGaFlmzZtcufn8G3ecccdbj3Fi77t27d7jRo18pKTk0PneL1e2bJlQ3HsM888416jdevW3r333uuWad3q1at7ffr0yde+RqP4MdqfuEURy2Qn8+eZ1+Pe/w516NAhdByJ2kVt6MfUGzZs8MqVK+e2G+6BBx5wz1cclxP9zZN5H33Rjq033ngjyzERLS7O/PeGjzgH2WGYHvB/45l1paB+/fruSpCugOjqVngvHl1Z83tjqGusejxp2JO67frDx8KH+PlXgXSlR12ANcxM/xd1S1YPJH/d3Kjbt7qK+7SP6q6sIo3hdMVQVzJyo6s6umqnKy+Z+Vc8xo0b57qVa791tc+/6eqGrlrl1M18/fr1rteWrqZpGz5tSz2dcqPu27Nnz3ZXtwpKrx3eaywn6hauK2Q+fc66r6twGr5XVPx20tVGdQP36eqU2irz5+v3GgunY0g9x3IatiZaJ7ynX0F07949Yhv+8asraKLvhIYcqveWrjr6x4xeW1frVq5cGZqlUseqX7tLPfW0jo6r448/PuL7lN/PU8fOzp073ZW9nI7/5s2bR72y6R//ef2+Z6YYVNvXlUr9P/y7ozbQ1eDMz/fb1B/aAQDxSL/r1WtavUvUG9ineOaKK65wPaD9c9nkyZOtbdu2Eb2HdJ7MqUdT5rhOPWxHjx4dWqa4S71y1HM83s4j4fQ6el7mc77OodofDX/PrdyCYrXwGFUxss7P/vleFKNoGF+7du1Cy3Qev+mmm1xvHvVyFm1Hn716a4liYS3TzY+L9dkoNvZfMz/7WpyxTKyPe5/aMLwHkt+GKgEhGtmgY+nvf/97xPOixfX5FR5rqZeV3rt66UlOx11OiHOQHZJRgJkbX66gQ92KNVxLv3ijdQVX92MlCjSGWt2RdXLW2HgFBj4NjTv22GNDJ1j/pKs6Tkqu6GSnbskKTPKajNL2wukEpRnRMo/TVnfivBQqV10oBRU5FQ3XyVbvS0PA9D7Db+qerkRNdvyTZeb9Fr1ubtTtWIGJkoMKdDR8LTwAygsN/corBaxKQIZTLS3JbSx8YfjtFK1NNHxTx6EC4nANGjSIeoLPS7D2v4t1BZfba6tbv17j/vvvz3LMqKu5+MeNjn8NY9Qxou+akqNaz+++X9DPU4GZPjsNfVQyWcMn9EdN5uNfNcxyk5fve2aq6aCAWl3aM7eBnyjO/N3xP5eCdH0HgNJCvx81pCu7c57OC349TJ0fo838mnmZfh+rtpB/UyJBdLFDiSsNB/frKioxpd/nGh4eb+eRvJzzda7VsEMN91OsqrhU8ZbaLbfzvX/OD4819Bll91n6j4uGC6qmUbS4eN68eS7h4T/mJ7bys6/FGcvE+rjP6z76bZv5+6CEbWEvPOo7pOGoanclpvS+/Rgsp+M2J8Q5yA41owAzl/DQlSrRlQudDHW1YsWKFaGx6//5z39cDxY9fvfdd7skjV8EM7zot+j5umqh+j/qWaMClgpadLVNJ1zVGNB2NTY+lvLaEygvdHLUewy/qhjOL35YFHQ1SoGKCp7ratITTzzhgpJ33nnHBYdBt0VOiQJdqQpSdjPx5ZZoUhBc2KuLub22P8Od6jrp6mE0fuD02GOPuUBPQb7qQSmA0h8PqoMRbaa8vH6eOmbV22zKlCkuiNVNBW/VuzA/M9bl5/sezt93XXlXb65o/LoMPv9zUUIOAJB3+qM5/He76g76E4ro977iByWkVLdJtYJULzO8x3a8nEfC6XyqmCXaOV/nWPW4Upvo/ek8rP1RT6DwmLSgsUY0qo+kmkgaMaBEjxJKivGU7Ni7d6/rCa/YuHHjxhGxZV73tThjmaISy/YvSAyuXmw6ZtUzUX+vqE3OO++8As9kTJyD7JCMAjLxAwUVzlSxbhUuFPWaUvdaJUTCExP+VZJwOskqcNFsLEpWqMCj/tBWkspPRmlZdiebaL2UMp+MdELPKRjJiQqU6+SvICC7IuRaR8W1VcAxv4kdv0h25v0WJfjyQt2XdXVSN12B0pU1FXL3k1Gx7EWiHmvqgRTeO+q7775zP/0imf6VpvCZX8KvToXL67757RStTTSLi5ITmXtsFZSCPHX7L0p+93MdU7nN2qfvk75jKuYaTu1b2KSMegcqgNVNgZOOIRUKVSCrAFLHtnre5bZ/ef2+h1MgrSG1+t7nZeZC0cQA+v3g98YDgHik34/qIZPdOU+/B9Uj2j8/Ks7JLPMyFYMOH3YX3itEFwGVtNBFNfVwUuFrTRASj+eRcOr1rv3TuSUaPXbnnXe6m+I0JRyGDBnikmf5oc8ou8/Sfzw8LtZFRcWVOscrJlGbqBi64mLdlCiMxb4WNj7MTywT6+M+r/y21fchvOe4hhLm5cJjdm2k5+piumbZ04V0X7R4Pj+Ic5AdhukBUWh2C/WW0uwV/qwUfuIo/KqEEjqzZs3K8nx/+J1OvEoY+VfhtFy/5NUtOa9D9ETT6WrceniAo3pDee0llJlmKNEQMCXbMvPfn66MKBBSr5XMNE49c1ImcyJJAYOuIIZ36dVQSL+GQHb0mpm7AetqoobSaRY1n5I0Be0uHO39KMj0aTpm3VcAoRpZ4s8wGD4jjPZV3egzy+u+hbdTeHsqwFWPMA0ZjRXV3lCQkd/hjvmhz0nfHbWdjs/Mwqcl1vcp8xU+1SnLTx2GaDJPPawgz0/a+sePjn/NOqOed5n5+5Sf73s4PU/bV+Iv2h8qmadmFvWeVECe29V6ACjN9Pvx3HPPdbOHhg+B16xs6rWkC3b+jKLqkaLft+qhFD58KHNvbdU2UsLAv/nnbN/VV1/tzqeK59RDOC9xU2k8j0Q75yvWDKehYplnWlNso8RXeHyVV4pRNCtg+PvRhT3FRbqQF14jVDGvXkOfgz5nPxmi5Zr1ThcFw+PiwuyrfxEvpzg1VrFMrI/7vNJMj0o6ala8cNHi+miUHIvWRtGOWdHnVhjEOcgOPaOAbKh7quoKjBo1yhWN1hUbXd1SsUpNQ6ss//Dhw93JVjWUwumqmaZD1VWQ8GKCGvN+7733uv/nJxmlLtc6WalWgE5eOinoNTRVcEGoq7kSXH379nWBhPZFAYSuWOnq34UXXui6uquIt3qJKRjUiVRXiXR1REmDYcOGuULq2dHz1E7abw3FUhCpK5L6oztze4VT0k1XMLVtFQdV92Dt19y5c93VMJ8CTk1xq/egAvFaT1cwC0KJLiUOFSSod4q2q/esgMrvOab9VgFHTaWr96LPRD3flMjKLD/7piEECo4VOGoKZQ3tVDspMaFaWbGiz0KBi9pShTGLsv6aPvNmzZq541NXGHXMKljVdNcK3kXfp4ceesgd0+ol+PXXX7s/MsKLexbEjTfe6D6fs88+2x1H6rmm9lTSz69joe+2Err6fuvY1Oel52jSAn2nddzl5/ue2eDBg12Bfw1LUBvoOdq+Cn+q/f2aJqLeiZrWOXMRUgAorUaMGJGlxpI/pO6RRx5xF6Z0ntDvPZ2X9Ee/EgyqCRTe40m9XzSZh+IoJRheeeUVV0tHv0Pz2vtFJRe0LSWNNJV9dr3BS/N5JBrFcUryqJe33+tW/1cSQxcbtT21vdpF5+jLLrvM8ksjB9544w0Xw9x+++0uLtLFNb1PJdL8SUpEMY5eT3FxeAyiuNhPqITHxYXZVz8hqX1SUlMJlvy+v7zGMnmV1+M+rzTEUd8nxcUXXHCBG0KnfdKQUvU8y+37oREPalfFqjo+9NmpJ6Fufn0uxSeqRatkbna97PKCOAc5ynaePSDBpyHWNLNHH320u2l6Xk2x+thjj7npaDW97UknneRNmDDBTZ+qZZldeumlbttjx44NLduzZ49XuXJlN73rn3/+mev++dPaa0rV/v37e7Vq1fIqVarkdenSxfvpp58i1tVUqk2aNIm6nWhTrWrq1vvuu89NwXvQQQd5derU8S655JKIaWflpZde8lq2bOleV1PQaqrbe+65x01Jm5v//ve/3gknnODaKyUlxU2BHK29wqeX1TTId999t9e8eXP3egcffLD7//PPPx/xnB07dnhXXHGFmwpYz/e36bfZuHHjsm1P/czcbvPmzfPatm3rVaxY0W3rueeey/J8tY2m29X70dTM//jHP7ypU6dm2WZ2++ZPK6zjLtzHH3/snXbaaa6NNZ30+eef7y1fvjxiHbWPnqvpeMNFm1o3OxdccIGbrji3Nsn8Gfn7HW2K5WhTA6udrrnmGndM6dg68sgjvb/+9a/e22+/HVpH0yVrimhNXa33rfc/a9asLMdqTp9nNHqNc889131X9D1r0KCBd/PNN3vr16+PWE9ThPfq1cvtm9arV6+ee9/+NNr5+b5Ha4ONGze66aXr168f+n6p7fV9Cqdpx/X8lStX5un9AUBJ5Z+PsrutXbvWrbdgwQKvY8eO3iGHHOJiorPOOsubOXNmlu0tXLjQO/30093vYP2OHjRokPfMM8+4bWlq+7zq3Lmze06014iH80g0iqVq1qzpPfzww6Fl2i9tr3Hjxi62qlatmtemTRvvrbfeiniu9k1xZl5iSZ3vFTsq3lH81Lp1a/ceo0lNTXXvc/bs2aFlP//8s1um9xgur/sajWL22267zTv88MO9pKQkt/2iimWyE217eTnus/u7JFqspvd5//33u/1THHX22Wd733zzjVejRg3vlltuyXUf9dqK73Xshu+vPpOuXbu6z1Ttrr9nFPNnfk/R4s9oxwhxDnKSpH9yTlcBKC4qwqm6OuqJlFMvJCAvVJNBXc9VoyDaTIcIngrb6gpmtKEeAIBIKmqtHiXqWZTXupvqmaTet9FqUMUzlVlQ/VL1aM9rW6F007A71U1TT6z77rvPSgLiHOSEmlEAkCDUBV7DLQvSJRyxp4kMJkyYELUuGwAkOg1bz1zLSUPPNNQpr8kV1fyZOHGiqx2VaPr06eOSdiopgPj/foTXdtKFx5KAOAe5oWYUACQQ1RNAyaDaI9FqjgEA/ldnSH9U63el6vVo9tWMjAw3o11uVOPmyy+/dHWmVCdKNTATjepVajZixCfVe1JdWxWS12f9xRdfuBpeuuiombBLAuIc5IZkFAAAAIASRX9kq0i4JhPRcOaTTz7ZJaRUYDk3mhhCE2So4LmKamtSGSCeaIZHFUJXb3claf2i5hqiB5QW1IwCAAAAAABAYKgZBQAAAAAAgMCQjAIAAAAAAEBgqBkVIwcOHLB169ZZlSpV3Lh2AAAQ3zzPs+3bt1vdunWtTBmu72VGbAQAQGLx8hEbkYyKESWi6tevH6vNAQCAUmLt2rVWr1694t6NEofYCACAxLQ2D7ERyagYUY8ov9GrVq0aq80CAIASSjMY6UKUHwMgErERAACJJSMfsRHJqBjxh+YpEUUyCgCAxMHw/JzbhdgIAIDEkpSH0kUUOAAAAAAAAEBgSEYBAAAAAAAgMCSjAAAAEDPp6emWkpJiqamptCoAAIiKZBQAAABiJi0tzZYvX25z586lVQEAQFQkowAAAAAAABAYklEAAAAAAAAIDMkoAAAAAAAABIZkFAAAAAAAAAJDMgoAAAAAAACBIRkFAAAAAACAwJCMAgAAAAAAQGDKBfdSAAAAQOwk95sYcX/14C40LwAApQDJqFIabAkBFwAAAAAAKG0YpgcAAAAAAIDAkIwCAABAzKSnp1tKSoqlpqbSqgAAICqSUQAAAIiZtLQ0W758uc2dO5dWBQAAUZGMAgAAAAAAQGBIRgEAAAAAACAwzKYHAACAuMDswwAAlA70jAIAAAAAAEBgSEYBAAAAAAAgMCSjAAAAAAAAEBiSUQAAAAAAAAgMySgAAAAAAAAEhmQUAAAAAAAAAkMyCgAAAAAAAIEhGQUAAAAAAIDAkIwCAABAtv744w9r2LCh3XXXXbQSAACICZJRAAAAyNajjz5qp5xyCi0EAABihmQUAAAAolq5cqV9++231qlTJ1oIAADEDMkoAACAODRjxgw7//zzrW7dupaUlGTjx4/Psk56erolJydbxYoVrU2bNjZnzpyIxzU0b9CgQQHuNQAASAQkowAAAOLQzp07rXnz5i7hFM3YsWOtb9++NnDgQFuwYIFbt2PHjrZp0yb3+HvvvWfHHXecuwEAAMRNMkpX2lJTU61KlSpWq1Ytu+iii2zFihUR6+zatcvS0tKsRo0adsghh9jFF19sGzdujFhnzZo11qVLF6tcubLbzt1332379u2LWOfTTz+1k08+2SpUqGDHHHOMjRo1Kt9XBwEAAEoLDa175JFHrGvXrlEfHzp0qPXs2dOuu+46S0lJseHDh7tYasSIEe7xr776yt58800XG6mH1Msvv2wPPfRQtq+3e/duy8jIiLgBAACUuGTUZ5995hJNCnamTp1qe/futXPPPdddyfP16dPHPvjgAxs3bpxbf926ddatW7fQ4/v373eJqD179tjMmTPttddec4mmAQMGhNZZtWqVW+ess86yRYsW2R133GE33nijTZkyJc9XBwEAAOKF4qb58+dbhw4dQsvKlCnj7s+aNSt00XDt2rW2evVqe/LJJ13iKjy+ykzrV6tWLXSrX79+IO8FAACUPsWajJo8ebJde+211qRJE5f8URJJvZwUHMm2bdvs1VdfdVfuzj77bGvZsqWNHDnSJZ2UwJKPPvrIli9fbv/5z3+sRYsW7irgww8/7Ho5KdASXelr1KiRDRkyxE444QTr1auXXXLJJfbUU0/l+eogAABAvNiyZYu7oFe7du2I5bq/YcOGAm2zf//+Lnbzb0pkAQAAlPiaUQpc5LDDDnM/lZRSb6nwq3aNGze2Bg0ahK7a6WezZs0igin1aFLX8GXLloXWCd+Gv46/jbxcHQQAAEhUunio3lE5USmEqlWrRtwAAACiKWclxIEDB9zwudNOO82aNm3qlunKXPny5a169erZXrXTz2hX9fzHclpHCas///zTfv/992yvDmo64+zqIujmoy4CAAAoLWrWrGlly5bNUodT9+vUqVOobat3um6KrQAAAEp0zyjVjlq6dKkrlFkaUBcBAACUVrrYp/IH06ZNi7gwqPtt27YtdEynEgpz586NwZ4CAIB4VCKSUarhNGHCBJs+fbrVq1cvtFxX5jSEbuvWrdletdPPaFf1/MdyWkfdxytVqlSgq4PURQAAACXZjh073MQtuvkTuuj/qs8pmrhFM+Rp8pdvvvnGbr31VjeJjOpnAgAAxG0yyvM8l4h699137ZNPPnFFxsPpit1BBx0UcdVuxYoVLojyr9rp59dffx0x651m5lOiSYXI/XXCt+Gv42+jIFcHqYsAAABKsnnz5tlJJ53kbn7ySf/3Z8Tr3r27qwOl+5oERokqTS6TuWxBfmmInmKw1NTUmLwPAAAQf5I8ZYSKyd///ncbM2aMvffee3b88ceHlms6YPVYEl2lmzRpkptpTwmm2267zS3XjHqiegQKoOrWrWuPP/64qw919dVX24033miPPfZY6Eqg6lCp2/j111/vEl+33367TZw40RUyl7Fjx1qPHj3sxRdftNatW9vTTz9tb731lqsZlZegTDWjtN8qwl4UBTuT+03Msmz14C4xfx0AAJA3RX3uL+2CaJ9o8VFmxEsAAJS8c3+xFjB/4YUX3M/27dtHLB85cqSbtUWeeuopN7PdxRdf7AqGK3n0/PPPh9bV8DoN8VPSSr2YDj74YJdUeuihh0LrqMeVEk99+vSxYcOGuaGAr7zySigR5V8d3Lx5s7s6qISWElyxuDoIAAAAAACAEtIzKp7QMwoAgMRCz6jibx96RgEAUDrP/SWigDkAAADiAzWjAABAbkhGAQAAIGZUo3P58uU2d+5cWhUAAERFMgoAAAAAAACBIRkFAAAAAACAwJCMAgAAQMxQMwoAAOSmXK5rAAAAAPmoGaWbP6NOcYs2497qwV2KZV8AAMD/0DMKAAAAAAAAgSEZBQAAAAAAgMCQjAIAAAAAAEBgSEYBAAAgZihgDgAAckMyCgAAADGj4uXLly+3uXPn0qoAACAqklEAAAAAAAAIDMkoAAAAAAAABIZkFAAAAAAAAAJDMgoAAAAAAACBIRkFAACAmGE2PQAAkBuSUQAAAIgZZtMDAAC5IRkFAAAAAACAwJCMAgAAAAAAQGBIRgEAAAAAACAwJKMAAAAAAAAQGJJRAAAAAAAACAzJKAAAAAAAAASGZBQAAABiJj093VJSUiw1NZVWBQAAUZGMAgAAQMykpaXZ8uXLbe7cubQqAACIimQUAAAAAAAAAkMyCgAAAAAAAIEhGQUAAAAAAIDAkIwCAAAAAABAYEhGAQAAAAAAIDDlgnspxFpyv4lZlq0e3IWGBgAAAAAAJRY9owAAAAAAABAYklEAAAAAAAAIDMkoAAAAAAAABIZkFAAAAGImPT3dUlJSLDU1lVYFAABRUcAcAAAAMZOWluZuGRkZVq1atVIxCQwTwAAAECx6RgEAAAAAACAwJKMAAAAAAAAQGJJRAAAAAAAACAzJKAAAAAAAAASGZBQAAAAAAAACQzIKAAAAAAAAgSEZBQAAAAAAgMCQjAIAAAAAAEBgSEYBAAAAAAAgMCSjAAAAAAAAEBiSUQAAAAAAAAgMySgAAABEtXXrVmvVqpW1aNHCmjZtai+//DItBQAACq1c4TcBAACAeFSlShWbMWOGVa5c2Xbu3OkSUt26dbMaNWoU964BAIBSjJ5RAAAAiKps2bIuESW7d+82z/PcDQAAoDBIRgEAAMQp9Wo6//zzrW7dupaUlGTjx4/Psk56erolJydbxYoVrU2bNjZnzpwsQ/WaN29u9erVs7vvvttq1qwZ4DsAAADxiGQUAABAnNLQOiWSlHCKZuzYsda3b18bOHCgLViwwK3bsWNH27RpU2id6tWr2+LFi23VqlU2ZswY27hxY4DvAAAAxCOSUQAAAHGqU6dO9sgjj1jXrl2jPj506FDr2bOnXXfddZaSkmLDhw93w/JGjBiRZd3atWu7ZNXnn38ewJ4DAIB4RjIKAAAgAe3Zs8fmz59vHTp0CC0rU6aMuz9r1ix3X72gtm/f7v6/bds2N+zv+OOPj7o91ZTKyMiIuAEAAERDMgoAACABbdmyxfbv3+96PIXT/Q0bNrj///TTT3b66ae7HlH6edttt1mzZs2ibm/QoEFWrVq10K1+/fqBvA8AAFD6lCnJRTWvvfZatzz8dt5550Ws89tvv9mVV15pVatWdTUNbrjhBtuxY0fEOkuWLHEBlApzKjB6/PHHs+zLuHHjrHHjxm4dBVmTJk0qoncNAABQOrRu3doWLVrkakYpnrr55puzXbd///6u95R/W7t2baD7CgAASo8yJbmopij5tH79+tDtjTfeiHhciahly5bZ1KlTbcKECS7BddNNN4UeVxfxc8891xo2bOi6oj/xxBP2wAMP2EsvvRRaZ+bMmXb55Ze7RNbChQvtoosucrelS5cW0TsHAAAoXpoVr2zZslkKkut+nTp18r29ChUquIuD4TcAAIBoylkxF9XULbfAJruA6JtvvrHJkyfb3LlzrVWrVm7Zs88+a507d7Ynn3zS9bgaPXq0q4mgQpzly5e3Jk2auCt8KtjpJ62GDRvmkl6arlgefvhhl9x67rnnXCFPAACAeKO4qGXLljZt2jR3EU4OHDjg7vfq1avA29VFRt00BBAAAKBU1oz69NNPrVatWq5Y5q233mq//vpr6DEV19TQPD8RJSq6qeKbs2fPDq1zxhlnuIDLpymLV6xYYb///ntonfDinf46fvFOAACA0kilC3QRTjdZtWqV+/+aNWvc/b59+9rLL79sr732mrvIp1hLPdc1u15BpaWl2fLly93FQgAAgBLXMyo36q3UrVs3a9Sokf3www/2j3/8w/WkUpJI3cpVXFOJqnDlypWzww47LFR4Uz/1/HB+oU49duihh7qfORXvzG7GGN18zBgDAABKmnnz5tlZZ50Vuq/kk/To0cNGjRpl3bt3t82bN9uAAQNc3NOiRQvX6zxzXAQAAJAwyajLLrss9H8VFT/xxBPt6KOPdr2lzjnnnGLdN80Y8+CDDxbrPgAAAOSkffv25nlejutoSF5hhuVlxjA9AABQqpNRmR111FGu2Ob333/vklGqJbVp06aIdfbt2+dm2PPrTOlntMKc/mM5rZNT8U7NGONfXfR7RjGFMQAASHQapqebYqNq1apZaZDcb2KWZasHdymWfQEAIBGU+JpR4X7++WdXM+qII45w99u2bWtbt251s+T5PvnkE1d8s02bNqF1NMPe3r17Q+uoOLlqUGmInr+OinWG0zpanh1mjAEAAAAAAChlyaicimrqMc1u99VXX9nq1atdsujCCy+0Y445xhUXlxNOOMHVlerZs6fNmTPHvvzyS9fNXMP7NJOeXHHFFa54+Q033GDLli2zsWPHutnzwns19e7d29VHGDJkiH377bf2wAMPuBoLseyyDgAAkAg0TC8lJcVSU1OLe1cAAEAJVazJKCV8TjrpJHcTJYj0fxXRVIHyJUuW2AUXXGDHHXecSyZp+uHPP//c9UryjR492ho3buyG7XXu3NnatWtnL730UuhxdQ//6KOPXKJLz7/zzjvd9m+66abQOqeeeqqNGTPGPa958+b29ttv2/jx461p06YBtwgAAEDpxmx6AACgRNeMyq2o5pQpU3LdhmbOUyIpJyp8riRWTi699FJ3AwAAAAAAQNEpVTWjAAAAAAAAULqRjAIAAAAAAEBgSEYBAAAgZihgDgAAckMyCgAAADFDAXMAAJAbklEAAAAAAAAIDMkoAAAAAAAABIZkFAAAAAAAAEp2MurHH3+M/Z4AAACg1MdZFDAHAABFkow65phj7KyzzrL//Oc/tmvXroJsAgAAAHEYZ1HAHAAAFEkyasGCBXbiiSda3759rU6dOnbzzTfbnDlzCrIpAAAAEGcBAIAEUqBkVIsWLWzYsGG2bt06GzFihK1fv97atWtnTZs2taFDh9rmzZtjv6cAAAAJgDgLAADEu0IVMC9Xrpx169bNxo0bZ//617/s+++/t7vuusvq169v11xzjUtSAQAAgDgLAAAgJsmoefPm2d///nc74ogjXI8oJaJ++OEHmzp1qus1deGFFxZm8wAAAAmLOAsAAMSrcgV5khJPI0eOtBUrVljnzp3t9ddfdz/LlPlfbqtRo0Y2atQoS05OjvX+AgAAxLXSHmdpNj3d9u/fX9y7AgAA4ikZ9cILL9j1119v1157resVFU2tWrXs1VdfLez+AQAAJJTSHmdpNj3dMjIyrFq1asW9OwAAIF6SUStXrsx1nfLly1uPHj0KsnkAAICERZxVMiT3mxhxf/XgLsW2LwAAxJsC1YxS13EVLc9My1577bVY7BcAAEBCIs4CAADxrkDJqEGDBlnNmjWjdhl/7LHHYrFfAAAACYk4CwAAxLsCJaPWrFnjimdm1rBhQ/cYAAAACoY4CwAAxLsCJaPUA2rJkiVZli9evNhq1KgRi/0CAABISMRZAAAg3hUoGXX55Zfb7bffbtOnT3fT9ur2ySefWO/eve2yyy6L/V4CAAAkCOIsAAAQ7wo0m97DDz9sq1evtnPOOcfKlfvfJg4cOGDXXHMNNaMAAAAKobTHWenp6e6mi5UAAADRJHme51kBfffdd25oXqVKlaxZs2auZlSiysjIsGrVqtm2bdusatWqRT69cHaYdhgAgPg495f2OKuo2yc/8VEsEGMBABC7c3+Bekb5jjvuOHcDAABAbBFnAQCAeFWgZJS6XY8aNcqmTZtmmzZtcl3Hw6l+FAAAAIizAAAAYpKMUqFyJaO6dOliTZs2taSkpIJsBgAAAMRZAAAgwRQoGfXmm2/aW2+9ZZ07d479HgEAACQw4iwAABDvyhTkSeXLl7djjjkm9nsDAACQ4IizAABAvCtQMurOO++0YcOGWSEm4gMAAABxFgAASEAFGqb3xRdf2PTp0+3DDz+0Jk2a2EEHHRTx+DvvvBOr/QMAAEgoxFklU3K/iVmWrR7cpVj2BQCAhExGVa9e3bp27Rr7vQEAAEhwxFkAACDeFSgZNXLkyNjvCQAAAIizAABA3CtQzSjZt2+fffzxx/biiy/a9u3b3bJ169bZjh07Yrl/AAAACac0x1np6emWkpJiqampxb0rAAAgnnpG/fTTT3beeefZmjVrbPfu3faXv/zFqlSpYv/617/c/eHDh8d+TwEAABJAaY+z0tLS3C0jI8OqVatW3LsDAADipWdU7969rVWrVvb7779bpUqVQstVR2ratGmx3D8AAICEQpwFAADiXYF6Rn3++ec2c+ZMK1++fMTy5ORk++WXX2K1bwAAAAmHOAsAAMS7AvWMOnDggO3fvz/L8p9//tl1IwcAAEDBEGcBAIB4V6Bk1LnnnmtPP/106H5SUpIrqDlw4EDr3LlzLPcPAAAgoRBnAQCAeFegYXpDhgyxjh07uplSdu3aZVdccYWtXLnSatasaW+88Ubs9xIAACBBEGeVHsn9JmZZtnpwl2LZFwAA4j4ZVa9ePVu8eLG9+eabtmTJEtcr6oYbbrArr7wyoqA5AAAAiLMAAAAKnYxyTyxXzq666qqCPh0AAADEWQAAIAEVKBn1+uuv5/j4NddcU9D9AQAASGjEWQAAIN4VKBnVu3fviPt79+61P/74w8qXL2+VK1cmGQUAAFBAxFkAACDeFWg2vd9//z3ipppRK1assHbt2lHAHAAAoBCIswAAQLwrUDIqmmOPPdYGDx6c5WoeAAAAiLMAAABinozyi5qvW7culpsEAABAMcVZa9eutfbt21tKSoqdeOKJNm7cOD4LAABQPDWj3n///Yj7nufZ+vXr7bnnnrPTTjut8HsFAACQoEpSnKUE2NNPP20tWrSwDRs2WMuWLa1z58528MEHB7ofAAAgvhQoGXXRRRdF3E9KSrLDDz/czj77bBsyZEis9g0AACDhlKQ464gjjnA3qVOnjtWsWdN+++03klEAACD4YXoHDhyIuO3fv99dLRszZkwoYAEAAEDxxlkzZsyw888/3+rWreuSWuPHj8+yTnp6uiUnJ1vFihWtTZs2NmfOnKjbmj9/vtuX+vXr87ECAICSUzMKAAAAJcfOnTutefPmLuEUzdixY61v3742cOBAW7BggVu3Y8eOtmnTpoj11BvqmmuusZdeeimgPQcAAPGsQMP0FLTk1dChQwvyEgAAAAkplnFWp06d3C2n5/fs2dOuu+46d3/48OE2ceJEGzFihPXr188t2717txs6qPunnnpqttvSerr5MjIy8vw+AABAYilQMmrhwoXutnfvXjv++OPdsu+++87Kli1rJ598cmg9dQcHAABAyYuz9uzZ44be9e/fP7SsTJky1qFDB5s1a1aoePq1117r6lVdffXVOW5v0KBB9uCDD1qiS+43MeL+6sFdim1fAACIq2SUag9UqVLFXnvtNTv00EPdst9//91dVTv99NPtzjvvjPV+AgAAJISg4qwtW7a4GlC1a9eOWK773377rfv/l19+6YbynXjiiaF6U//+97+tWbNmWbanpFZ4ry71jKK+FAAAiFkySjO5fPTRR6EASfT/Rx55xM4991ySUQAAAAVUkuKsdu3auSLqeVGhQgV3AwAAKJIC5rrStXnz5izLtWz79u0F2SQAAAACjLNq1qzphv5t3LgxYrnu16lTp8DbVbH0lJQUS01NjcFeAgCAeFSgZFTXrl1dV/F33nnHfv75Z3f773//azfccIN169Yt9nsJAACQIIKKs8qXL28tW7a0adOmhZapF5Tut23btsDbTUtLs+XLl9vcuXNjtKcAACDeFCgZpZlWNDPLFVdcYQ0bNnQ3/f+8886z559/Ps/bmTFjhquLULduXVeE069F4FPRzAEDBtgRRxxhlSpVcgU1V65cmWWq4SuvvNKqVq1q1atXd4Hajh07ItZZsmSJq7FQsWJFV7vg8ccfz7Iv48aNs8aNG7t1VAdh0qRJ+W4XAACAwopVnCWKiRYtWuRusmrVKvf/NWvWuPuq8fTyyy+7+lTffPON3XrrrbZz587Q7HoAAAAlJhlVuXJlFwz9+uuvoRlflBTSsoMPPjjP21Gw07x5c9edOxoljZ555hkXlM2ePdttu2PHjrZr167QOkpELVu2zKZOnWoTJkxwCa6bbropoqu76isokNOMMU888YQ98MAD9tJLL4XWmTlzpl1++eUukaX3oumLdVu6dGlBmgcAAKDAYhVnybx58+ykk05yNz/5pP/rYp90797dnnzySXe/RYsWLlE1efLkLEXNAQAAYinJU/ejAvr+++/thx9+sDPOOMP1XNKmCjrNsJ737rvvuiSQaFvqMaUinXfddZdbtm3bNhccjRo1yi677DJ3BU81CdQNvFWrVm4dBVCdO3d2Xdr1/BdeeMHuu+8+27Bhg+uOLv369XO9sPyZYhSIKTGmZJbvlFNOcUGZEmF5oaRXtWrV3D6ql1ZRTxOcHaYPBgAgGEV97o9lnBUkXWTUTTP1fffdd0XWPvmJj4oTsRkAIFFk5CM2KlDPKF2pO+ecc+y4445ziZ/169e75epZFKsZXtSNXAkkDc3z6U21adPGZs2a5e7rp4bm+Yko0fplypRxPan8dRTE+YkoUe+qFStWuGmS/XXCX8dfx3+daHbv3u0aOvwGAABQWEHEWUWJmlFZE2aZbwAAJLoCJaP69OljBx10kKs3oK7kPvUwUs+kWFAiSjJ3E9d9/zH9rFWrVsTj5cqVs8MOOyxinWjbCH+N7NbxH49m0KBBLjnm31SLCgAAoLCCiLMAAACKU7mCPOmjjz6yKVOmWL169SKWH3vssfbTTz9ZIujfv7+ru+BTzygSUgAAoLBKe5wVPkwP0UXrHcVwPgBAIilQzyjVVwq/UudTcc0KFSrEYr+sTp067ufGjRsjluu+/5h+btq0KeLxffv2uf0IXyfaNsJfI7t1/Mej0fvUGMjwGwAAQGEFEWcVJYbpAQCAIklGnX766fb666+H7quY5oEDB9zsd2eddVZMWr1Ro0YuGTRt2rSI3keqBdW2bVt3Xz+3bt3qZsnzffLJJ25fVFvKX0cz7O3duze0jmbeO/744+3QQw8NrRP+Ov46/usAAAAEJYg4CwAAoNQN01MwpMKami54z549ds8999iyZcvcFbsvv/wyz9vZsWOHmykmvGi5phRWzacGDRrYHXfcYY888ojrlq7k1P333+9myPNn3DvhhBPsvPPOs549e7pZ75Rw6tWrl5tpT+vJFVdcYQ8++KAr+nnvvffa0qVLbdiwYfbUU0+FXrd379525pln2pAhQ6xLly725ptvuvf20ksvFaR5AAAACixWcRYAAEBc9Yxq2rSpm6q3Xbt2duGFF7ru5N26dbOFCxfa0UcfneftKMg66aST3E1Ug0n/HzBggLuv4Ou2226zm266yVJTU13ySoU7K1asGNrG6NGjrXHjxi5o04wz2qfwJJKKi6v2ghJdLVu2dLPQaPvapu/UU0+1MWPGuOc1b97c3n77bRs/frx7nwAAAEGKVZwFAABQUiV5nufl5wnqfaTeSOqJpB5L+P9DCJX42rZtW5HUj8rrNMAUvwQAoPSe++MhzgovYK6kWlHFRvmJj0oDYjgAQCLFRvnuGaWphpcsWVKY/QMAAECcxlkUMAcAAEUyTO+qq66yV199tSBPBQAAAHEWAABIYAUqYL5v3z4bMWKEffzxx64O08EHHxzx+NChQ2O1fwAAAAmFOAsAAMS7fCWjfvzxR0tOTnYz0p188slumWoBhNP0wwAAAMgf4iwAAJAo8pWMUiHN9evX2/Tp09397t272zPPPGO1a9cuqv0DAABICPESZ4UXMAcAACh0zajME+99+OGHbrphAAAAFE68xFkUMAcAAEVSwDy7oAkAAACxQZwFAADiVb6SUaoHlbkmFDWiAAAACo84CwAAJIpy+b1Cd+2111qFChXc/V27dtktt9ySZTa9d955J7Z7CQAAEOeIswAAQKLIVzKqR48eEfevuuqqWO8PAABAQiLOAgAAiSJfyaiRI0cW3Z4AAAAksHiJs5hNDwAAFGkBcwAAACAcs+kBAIDckIwCAAAAAABAYEhGAQAAAAAAIDAkowAAAAAAABAYklEAAAAAAAAIDMkoAAAAAAAABIZkFAAAAAAAAAJDMgoAAAAxk56ebikpKZaamkqrAgCAqMpFXwwAAADkX1pamrtlZGRYtWrVaMKAJfebmGXZ6sFd+BwAACUKPaMAAAAAAAAQGJJRAAAAAAAACAzJKAAAAAAAAASGmlEAAAAAClSTinpUAICCoGcUAAAAAAAAAkPPKAAAAKCEYVY8AEA8o2cUAAAAAAAAAkMyCgAAAAAAAIEhGQUAAAAAAIDAUDMKAAAAMZOenu5u+/fvp1ULWSMKAIB4Rc8oAAAAxExaWpotX77c5s6dS6sCAICoSEYBAAAAAAAgMCSjAAAAAAAAEBiSUQAAAAAAAAgMySgAAAAAAAAEhmQUAAAAAAAAAkMyCgAAAAAAAIEhGQUAAAAAAIDAkIwCAAAAAABAYEhGAQAAAAAAIDAkowAAAAAAABCYcsG9FAAAAABEl9xvYsT91YO70FQAEKfoGQUAAIBsde3a1Q499FC75JJLaCUAABAT9IwCAABAtnr37m3XX3+9vfbaa7RSHKEXEgCgONEzCgAAANlq3769ValShRYCAAAxQzIKAAAgTs2YMcPOP/98q1u3riUlJdn48eOzrJOenm7JyclWsWJFa9Omjc2ZM6dY9hV5682U+QYAQGlEMgoAACBO7dy505o3b+4STtGMHTvW+vbtawMHDrQFCxa4dTt27GibNm0KfF8BAEDioGYUAABAnOrUqZO7ZWfo0KHWs2dPu+6669z94cOH28SJE23EiBHWr1+/fL3W7t273c2XkZFRiD0HAADxjGRUnKEYJQAAyIs9e/bY/PnzrX///qFlZcqUsQ4dOtisWbPy3YiDBg2yBx98kMYHAAC5YpgeAABAAtqyZYvt37/fateuHbFc9zds2BC6r+TUpZdeapMmTbJ69eplm6hSUmvbtm2h29q1a4v8PQAAgNKJnlEAAADI1scff5yn1qlQoYK7AQAA5IaeUQAAAAmoZs2aVrZsWdu4cWPEct2vU6dOgberYukpKSmWmpoag70EAADxiGQUAABAAipfvry1bNnSpk2bFlp24MABd79t27YF3m5aWpotX77c5s6dG6M9BQAA8YZhegAAAHFqx44d9v3334fur1q1yhYtWmSHHXaYNWjQwPr27Ws9evSwVq1aWevWre3pp5+2nTt3hmbXAwAAKAokowAAAOLUvHnz7KyzzgrdV/JJlIAaNWqUde/e3TZv3mwDBgxwRctbtGhhkydPzlLUPL/D9HRTcXQEP5My8t5Oqwd3obkAoJiU6GF6DzzwgCUlJUXcGjduHHp8165drit4jRo17JBDDrGLL744S92DNWvWWJcuXaxy5cpWq1Ytu/vuu23fvn0R63z66ad28sknu6KbxxxzjAvOAAAASrv27dub53lZbuGxTq9eveynn36y3bt32+zZs61NmzaFek2G6QEAgFKdjJImTZrY+vXrQ7cvvvgi9FifPn3sgw8+sHHjxtlnn31m69ats27duoUe1xU5JaL27NljM2fOtNdee80FX7r6F95dXevoqqG6rd9xxx1244032pQpUwJ/rwAAAAAAAPGuxA/TK1euXNQZXbZt22avvvqqjRkzxs4++2y3bOTIkXbCCSfYV199Zaeccop99NFHroCmpiRWd3N1PX/44Yft3nvvdb2uVLhz+PDh1qhRIxsyZIjbhp6vhNdTTz1lHTt2DPz9AgAAAAAAxLMS3zNq5cqVVrduXTvqqKPsyiuvdMPuZP78+bZ3717r0KFDaF0N4VMxzlmzZrn7+tmsWbOIugdKMGVkZNiyZctC64Rvw1/H30Z21JVd2wm/AQAAJDrVi0pJSbHU1NTi3hUAAFBClehklGoWaFidCmm+8MILbkjd6aefbtu3b3dFNtWzqXr16hHPUeJJj4l+Zi7A6d/PbR0ll/78889s923QoEFWrVq10K1+/foxe98AAAClFTWjAABAqR6m16lTp9D/TzzxRJecatiwob311ltWqVKlYt23/v37h2akESWvSEgBAAAAAACU4p5RmakX1HHHHWfff/+9qyOlwuRbt26NWEez6fk1pvQz8+x6/v3c1qlatWqOCS/NvKd1wm8AAAAAAAAoxT2jMtuxY4f98MMPdvXVV1vLli3toIMOsmnTptnFF1/sHl+xYoWrKdW2bVt3Xz8fffRR27Rpk9WqVcstmzp1qkscqZaBv86kSZMiXkfr+NsAAABA/mpG6aZZjQEkruR+EyPurx7cpdj2BUhkyZm+iyXl+1iie0bddddd9tlnn9nq1att5syZ1rVrVytbtqxdfvnlrk7TDTfc4IbKTZ8+3RU0v+6661wSSTPpybnnnuuSTkpeLV682KZMmWL//Oc/XS0D9WySW265xX788Ue755577Ntvv7Xnn3/eDQPs06dPMb97AACA0oeaUQAAoFT3jPr5559d4unXX3+1ww8/3Nq1a2dfffWV+7889dRTVqZMGdczSrPbaRY8JZN8SlxNmDDBbr31VpekOvjgg61Hjx720EMPhdZp1KiRTZw40SWfhg0bZvXq1bNXXnnFbQsAAAAAAAAJlIx68803c3y8YsWKoa7g2VHB88zD8DJr3769LVy4sMD7CQAAAAAAgDgYpgcAAAAAAID4UqJ7RgEAAKB0oYB56SheW5TPK26ldb8BIJHQMwoAAAAxQwFzAACQG5JRAAAAAAAACAzJKAAAAAAAAASGZBQAAAAAAAACQzIKAAAAAAAAgWE2PQAAAMQMs+mVTsxABwAIEj2jAAAAEDPMpgcAAHJDMgoAAAAAAACBIRkFAAAAAACAwJCMAgAAAAAAQGBIRgEAAAAAACAwJKMAAAAAAAAQGJJRAAAAAAAACEy54F4KAAAA8S49Pd3d9u/fX9y7gmKS3G9ixP3Vg7vEZDuF2VZpRRvEn1h9P4DSjp5RAAAAiJm0tDRbvny5zZ07l1YFAABRkYwCAAAAAABAYEhGAQAAAAAAIDAkowAAAAAAABAYklEAAAAAAAAIDMkoAAAAAAAABIZkFAAAAAAAAAJDMgoAAAAAAACBIRkFAAAAAACAwJCMAgAAAAAAQGBIRgEAAAAAACAw5YJ7KQAAAMS79PR0d9u/f39x7woCkNxvYoHWWT24S6D7UNDt5GU/C/r6BW2DvLxeXredeVux/FxKq6I+Xksr2gWxRs8oAAAAxExaWpotX77c5s6dS6sCAICoSEYBAAAAAAAgMCSjAAAAAAAAEBiSUQAAAAAAAAgMySgAAAAAAAAEhmQUAAAAAAAAAlMuuJdCcWAKTgAAAAAAUJLQMwoAAAAAAACBIRkFAAAAAACAwJCMAgAAAAAAQGBIRgEAAAAAACAwJKMAAAAAAAAQGJJRAAAAiGrChAl2/PHH27HHHmuvvPIKrQQAAGKiXGw2AwAAgHiyb98+69u3r02fPt2qVatmLVu2tK5du1qNGjWKe9cAAEApR88oAAAAZDFnzhxr0qSJHXnkkXbIIYdYp06d7KOPPqKlAABAoZGMAgAAiEMzZsyw888/3+rWrWtJSUk2fvz4LOukp6dbcnKyVaxY0dq0aeMSUL5169a5RJRP///ll18C238AABC/SEYBAADEoZ07d1rz5s1dwimasWPHumF4AwcOtAULFrh1O3bsaJs2bQp8XwEAQGIhGQUAABCHNKzukUcecXWeohk6dKj17NnTrrvuOktJSbHhw4db5cqVbcSIEe5x9agK7wml/2tZdnbv3m0ZGRkRNwAAgGgoYA4AAJBg9uzZY/Pnz7f+/fuHlpUpU8Y6dOhgs2bNcvdbt25tS5cudUkoFTD/8MMP7f777892m4MGDbIHH3wwkP1H6Zfcb2KgzyuJ4um9xPL9rh7cxeJFrD7jaNspie1U0P0syvdXWtouEdEzCgAAIMFs2bLF9u/fb7Vr145YrvsbNmxw/y9XrpwNGTLEzjrrLGvRooXdeeedOc6kp8TWtm3bQre1a9cW+fsAAAClEz2jAAAAENUFF1zgbnlRoUIFdwMAAMgNPaMAAAASTM2aNa1s2bK2cePGiOW6X6dOnUJtWwXTVYMqNTW1kHsJAADiFT2jEhDjZgEASGzly5e3li1b2rRp0+yiiy5yyw4cOODu9+rVq1DbTktLczcVMFetKQAAgMxIRgEAAMShHTt22Pfffx+6v2rVKlu0aJEddthh1qBBA+vbt6/16NHDWrVq5YqVP/3007Zz5043ux4AAEBRIhkFAAAQh+bNm+eKj/uUfBIloEaNGmXdu3e3zZs324ABA1zRchUpnzx5cpai5gUZpqebCqQDAABEQzIKAAAgDrVv3948z8txHQ3JK+ywvMwYpgcAAHJDAXMAAAAAAAAEhmRUJupWnpycbBUrVrQ2bdrYnDlzLFGKmoffAAAAAAAAigLJqDBjx4519RQGDhxoCxYssObNm1vHjh1t06ZNRdL4AAAA8XhhLyUlxVJTU4t7VwAAQAlFzagwQ4cOtZ49e4ZmkRk+fLhNnDjRRowYYf369bNEEq131OrBXYplXwAAQOlBzSgAAJAbklH/Z8+ePTZ//nzr379/qHHKlCljHTp0sFmzZuXakIkgL8P3SFgBAAAAAICckIz6P1u2bHFTEGeezlj3v/322ywNt3v3bnfzbdu2zf3MyMiwonBg9x9WGjToMy5m21r6YMdc12k6cEqBnpcXRbltAEDp55/zc5uxLlH57VJUsVFpio9QMmU+NqMdT3k5fkvicZjX713mfY/l97Wg7VKUvzPyoqDHQV63VZBtx3KfCiov+xDL71Cs3l9JaLvidiDANshPbJTkEUE569atsyOPPNJmzpxpbdu2DTXQPffcY5999pnNnj07ouEeeOABe/DBB2P92QEAgFJm7dq1Vq9eveLejRLn559/tvr16xf3bgAAgBIYG9Ez6v/UrFnTypYtaxs3boxoIN2vU6dOlobTcD4VO/cdOHDAfvvtN6tRo4YlJSVZrLOLCub0gVatWjWm2wZtXlJwnNPmiYDjPL7aXNfztm/fbnXr1o3pduOF2kXtXqVKlZjHRsL3KXi0Oe0d7zjGafNEkFFCYiOSUf+nfPny1rJlS5s2bZpddNFFoQST7vfq1StLw1WoUMHdwlWvXt2Kkg4UklHBos2DR5vT5omA4zx+2rxatWox32a8UO3NIHqM8X0KHm1Oe8c7jnHaPBFULebYiGRUGPV06tGjh7Vq1cpat25tTz/9tO3cuTM0ux4AAAAAAAAKh2RUmO7du9vmzZttwIABtmHDBmvRooVNnjw5S1FzAAAAAAAAFAzJqEw0JC/asLzipOGAAwcOzDIsELR5POE4p80TAcc5bQ6+T6UZv8No73jHMU6bJ4IKJSS/wGx6AAAAAAAACEyZ4F4KAAAAAAAAiY5kFAAAAAAAAAJDMgoAAAAAAACBIRlVCqSnp1tycrJVrFjR2rRpY3PmzCnuXSoVBg0aZKmpqValShWrVauWXXTRRbZixYqIdXbt2mVpaWlWo0YNO+SQQ+ziiy+2jRs3RqyzZs0a69Kli1WuXNlt5+6777Z9+/ZFrPPpp5/aySef7IrAHXPMMTZq1ChLdIMHD7akpCS74447Qsto79j75Zdf7KqrrnLHcKVKlaxZs2Y2b9680OOe57kZQo844gj3eIcOHWzlypUR2/jtt9/syiuvtKpVq1r16tXthhtusB07dkSss2TJEjv99NPd76H69evb448/bolo//79dv/991ujRo1cex599NH28MMPu3b20eaFM2PGDDv//POtbt267nfI+PHjIx4Psn3HjRtnjRs3duvouzVp0qRCvjvECrFRwRAbFT/io2AQHwWL+KjozYjH+MhDifbmm2965cuX90aMGOEtW7bM69mzp1e9enVv48aNxb1rJV7Hjh29kSNHekuXLvUWLVrkde7c2WvQoIG3Y8eO0Dq33HKLV79+fW/atGnevHnzvFNOOcU79dRTQ4/v27fPa9q0qdehQwdv4cKF3qRJk7yaNWt6/fv3D63z448/epUrV/b69u3rLV++3Hv22We9smXLepMnT/YS1Zw5c7zk5GTvxBNP9Hr37h1aTnvH1m+//eY1bNjQu/baa73Zs2e7Y3HKlCne999/H1pn8ODBXrVq1bzx48d7ixcv9i644AKvUaNG3p9//hla57zzzvOaN2/uffXVV97nn3/uHXPMMd7ll18eenzbtm1e7dq1vSuvvNJ9n9544w2vUqVK3osvvuglmkcffdSrUaOGN2HCBG/VqlXeuHHjvEMOOcQbNmxYaB3avHD0e/a+++7z3nnnHWX4vHfffTfi8aDa98svv3S/yx9//HH3u/2f//ynd9BBB3lff/11Id8hCovYqOCIjYoX8VEwiI+CR3xU9CbFYXxEMqqEa926tZeWlha6v3//fq9u3breoEGDinW/SqNNmza5L+5nn33m7m/dutV9cfTHpO+bb75x68yaNSv0pS9Tpoy3YcOG0DovvPCCV7VqVW/37t3u/j333OM1adIk4rW6d+/uAr5EtH37du/YY4/1pk6d6p155pmhZBTtHXv33nuv165du2wfP3DggFenTh3viSeeCC3T51ChQgV3chGdRHTMz507N7TOhx9+6CUlJXm//PKLu//88897hx56aOiY91/7+OOP9xJNly5dvOuvvz5iWbdu3dxJW2jz2MocbAXZvn/729/c5x2uTZs23s033xzjd4n8IjaKHWKj4BAfBYf4KHjER8GyOImPGKZXgu3Zs8fmz5/vutj5ypQp4+7PmjWrWPetNNq2bZv7edhhh7mfatu9e/dGtK+6GzZo0CDUvvqproe1a9cOrdOxY0fLyMiwZcuWhdYJ34a/TqJ+Rhr2qGGNmduE9o69999/31q1amWXXnqpG0J60kkn2csvvxx6fNWqVbZhw4aIz6JatWpuuG/4Ma5uutqOT+vrd83s2bND65xxxhlWvnz5iGNcw15///13SySnnnqqTZs2zb777jt3f/HixfbFF19Yp06d3H3avGgF2b78bi+ZiI1ii9goOMRHwSE+Ch7xUfFaVUrjI5JRJdiWLVvc+NvwRIjovg425N2BAwdc7aLTTjvNmjZt6papDfVF05cyu/bVz2jt7z+W0zpKWP35558J9TG9+eabtmDBAleTIjPaO/Z+/PFHe+GFF+zYY4+1KVOm2K233mq33367vfbaa6E2l5x+h+inElnhypUr55K2+fkeJIp+/frZZZdd5hLXBx10kEsA6neLxt8LbV60gmzf7NZJtGO+pCE2ih1io+AQHwWL+Ch4xEfFa0MpjY/K5fsZQCm9GrV06VLXgwFFY+3atda7d2+bOnWqK2aHYP6Q0NWNxx57zN1XYkTH+fDhw61Hjx58BEXgrbfestGjR9uYMWOsSZMmtmjRIpeMUjFJ2hxAaUJsFAzio+ARHwWP+AgFQc+oEqxmzZpWtmzZLLO76X6dOnWKbb9Km169etmECRNs+vTpVq9evdBytaG6+2/dujXb9tXPaO3vP5bTOpqlQDMZJAoNw9u0aZObVVBZdt0+++wze+aZZ9z/lTGnvWNLs2WkpKRELDvhhBPcDJDhx2hOv0P0U59bOM0Wqdk28vM9SBSaTdO/+qchvFdffbX16dMn1BuQNi9aQbZvdusk2jFf0hAbxQaxUXCIj4JHfBQ84qPiVaeUxkcko0owDSFr2bKlq08SnunX/bZt2xbrvpUGqu2mYOvdd9+1Tz75xE3FHk5tq2E24e2r8bD6Q95vX/38+uuvI7646vmjRJOfBNA64dvw10m0z+icc85xbaWeIv5NvXY0fMn/P+0dWxp2qmM2nGoZNWzY0P1fx7xODOHHp4aPalx4+DGuhKyCZZ++L/pdo3Hm/jqaTlY11sKP8eOPP94OPfRQSyR//PGHG1sfThcN1F5CmxetINuX3+0lE7FR4RAbBY/4KHjER8EjPipejUprfJTvkucIfPpiVcEfNWqUq4B/0003edWrV4+Y3Q3R3XrrrW56y08//dRbv3596PbHH3+E1rnlllu8Bg0aeJ988ok3b948r23btu7m27dvn9e0aVPv3HPP9RYtWuRNnjzZO/zww73+/fuH1vnxxx+9ypUre3fffbebjS89Pd1Nd6l1E134bHpCe8d+iuhy5cq56XRXrlzpjR492h2L//nPfyKmedXvjPfee89bsmSJd+GFF0ad5vWkk07yZs+e7X3xxRduNsTwaV41G4emeb366qvdNK/6vaTXCZ/mNVH06NHDO/LII70JEyZ4q1atctPr1qxZ082q6aPNCz/j1MKFC91NYcrQoUPd/3/66adA21dTF+v79eSTT7rf7QMHDizw1MWILWKjgiM2KhmIj4oW8VHwiI+K3vY4jI9IRpUCzz77rEuYlC9f3k1n/NVXXxX3LpUK+pJGu40cOTK0jr6cf//7390Ulvqide3a1SWswq1evdrr1KmTV6lSJfdH55133unt3bs3Yp3p06d7LVq0cJ/RUUcdFfEaiSxzsEV7x94HH3zgEqZKWjdu3Nh76aWXIh7XVK/333+/O7FonXPOOcdbsWJFxDq//vqrOxEdcsghXtWqVb3rrrvOnfDCLV682GvXrp3bhpIxOuElooyMDHdM63dyxYoV3ff9vvvui5gClzYvHP0+jfa7W4Fu0O371ltveccdd5z73d6kSRNv4sSJhXx3iBVio4IhNioZiI+KHvFRsIiPit70OIyPkvRP/vtTAQAAAAAAAPlHzSgAAAAAAAAEhmQUAAAAAAAAAkMyCgAAAAAAAIEhGQUAAAAAAIDAkIwCAAAAAABAYEhGAQAAAAAAIDAkowAAAAAAABAYklEAAAAAAAAIDMkoAKXW6tWrLSkpyRYtWlSkr/Prr79arVq13Otl9sADD0RdXlB6P+PHj8/z+p9++ql7ztatW/P1Onv27LHk5GSbN29eAfYSAACURMRGxEZAaUEyCkCpVb9+fVu/fr01bdq0SF/n0UcftQsvvNAlb/Lrs88+c/uZV3o/nTp1slhSwqxFixYRy8qXL2933XWX3XvvvTF9LQAAUHyIjfKG2AgofiSjAJRK6tlTtmxZq1OnjpUrV67IXuePP/6wV1991W644YaI5ePGjbOWLVvaE088YampqXbKKafYf//73yzPf++99+z888/P8+vp/VSoUMGCcOWVV9oXX3xhy5YtC+T1AABA0SE2KjxiIyA4JKMAFLv27dtbr1693K1atWpWs2ZNu//++83zvNA66pX08MMP2zXXXGNVq1a1m266KWpXdCVW/vrXv7p1qlSpYqeffrr98MMPocdfeeUVO+GEE6xixYrWuHFje/7553Pct0mTJrnkkJJNvu+++84uv/xy69Kli1177bU2cuRIS0tLs71792Z5/vvvv28XXHBB6H3efvvtds8999hhhx3mEk+6MpfTML2ZM2e6Xk3a31atWrnHog1NnD9/vnu8cuXKduqpp9qKFSvc8lGjRtmDDz5oixcvds/TTcvk0EMPtdNOO83efPPNPHxKAAAgKMRG/x+xERCfSEYBKBFee+0118Npzpw5NmzYMBs6dKhLHIV78sknrXnz5rZw4UKXrMrsl19+sTPOOMMljz755BOXoLn++utt37597vHRo0fbgAED3LC7b775xh577DG3Hb12dj7//HPXAyrckiVLrEyZMi7Jc/jhh7thgldffbVddtllEespMbZp0yY7++yzI97nwQcfbLNnz7bHH3/cHnroIZs6dWrU187IyHC9qpo1a2YLFixwybjshtXdd999NmTIEFcDSu2o9y3du3e3O++805o0aeKGAOqmZb7WrVu79wgAAEoWYqOsiI2A+FF0Y1sAIJ81Dp566il39ev444+3r7/+2t3v2bNnaB0ldZRY8WUuHJ6enu56Vqmnz0EHHeSWHXfccaHHBw4c6BI23bp1c/cbNWpky5cvtxdffNF69OgRdb9++uknq1u3bsQyJaeUjLr77rtzLByuIXodO3Z09Zl8J554otsPOfbYY+25556zadOm2V/+8pcszx8zZoxrj5dfftn1jEpJSXEJt/A28SnBduaZZ7r/9+vXz/Xa2rVrl1WqVMkOOeQQl6BST6zM9N70HgEAQMlCbERsBMQzekYBKBE0DE6JF1/btm1t5cqVtn///tAyDUPLiYauaVien4gKt3PnTjdcT7WflJzxb4888kjEML7M/vzzT5cICqcklnozLV261N544w07+eST7YorrsiyHSWj/CF64cmocEcccYTrPRWNhtpp/fDXV0+maMK3q21KdtsNp2SV6mIBAICShdgoK2IjIH7QMwpAqaHhbbklVrKzY8cO91O9jNq0aRPxmAqhZ0f1q37//fcsy5X0mjx5sqv5pCFwKnKunltKSKkXkobDaTiheiiFy5woUwLuwIEDVljh2/WTennZ7m+//eaGGgIAgNKH2Ch7xEZAyUbPKAAlgmoohfvqq6/cMLacEkXRegep/lG0QuK1a9d2Q9J+/PFHO+aYYyJu6umUnZNOOskN5cuJZtPTrHpr1qwJDXn74IMPXCFxFSovKH+44u7du0PL5s6dm+/taJhgeA+zcOrdpfcIAABKFmKjrIiNgPhBMgpAiaBETt++fV33aw19e/bZZ61379752oZm41NhSxUSVyFvDfP797//HZpZTgXHBw0aZM8884ybEU+JHs2Ep2Lp2VHNJxUiD+8dpR5RqmelxJZ6H2k4nLapXlQNGjTIMoteQWnon7avmQNVcH3KlCmuiLuED2nMjWYiXLVqlRvGuGXLlojklpJ35557bqH2EwAAxB6xUVbERkD8IBkFoES45pprXH0m1URKS0tziSglYfKjRo0abhY9DclTMW8VGtewPL+b9o033uhm6FMCSjPUaZ1Ro0bl2DNK66km1FtvvRWR3NHVSs3cpxn5zjnnHJcsmjBhgnst1adSUfLCJqOqVq3qelgpidSiRQs3Y55mA5TMdaxycvHFF9t5551nZ511lhuSp2SfzJo1y7Zt22aXXHJJofYTAADEHrFRVsRGQPxI8jzPK+6dAJDY2rdv75ItTz/9tJVEEydOdDPnaUibZtELp5pR1157rUtQ+d555x375z//mevwvoIYPXq0XXfddS6JlFONrLzo3r27NW/e3P7xj3/EbP8AAEDhERvlHbERUDpRwBwAcqEi5Bry98svv7hplnOjWfr+9a9/xaRdX3/9dTvqqKPsyCOPtMWLF9u9995rf/vb3wqdiNqzZ4/r9dWnT5+Y7CcAAEgcxEYACoueUQCKXUm/+lecHn/8cXv++edtw4YNdsQRR9hFF11kjz76qFWuXLm4dw0AABQRYqPsERsB8YFkFAAAAAAAAAJDAXMAAAAAAAAEhmQUAAAAAAAAAkMyCgAAAAAAAIEhGQUAAAAAAIDAkIwCAAAAAABAYEhGAQAAAAAAIDAkowAAAAAAABAYklEAAAAAAAAIDMkoAAAAAAAAWFD+H11NR/XU6+uWAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1200x400 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig, ax = plt.subplots(1, 2, figsize=(12, 4))\n",
     "df['price'].plot.hist(bins=100, ax=ax[0])\n",
@@ -179,10 +724,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "price-quantiles",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:38.099919Z",
+     "iopub.status.busy": "2026-05-14T05:21:38.099797Z",
+     "iopub.status.idle": "2026-05-14T05:21:38.105873Z",
+     "shell.execute_reply": "2026-05-14T05:21:38.104885Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.01     30.0\n",
+       "0.05     40.0\n",
+       "0.25     69.0\n",
+       "0.50    106.0\n",
+       "0.75    175.0\n",
+       "0.95    355.0\n",
+       "0.99    799.0\n",
+       "Name: price, dtype: float64"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df['price'].quantile([0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99])"
    ]
@@ -209,10 +779,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "geo-bounds",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:38.107769Z",
+     "iopub.status.busy": "2026-05-14T05:21:38.107652Z",
+     "iopub.status.idle": "2026-05-14T05:21:38.111006Z",
+     "shell.execute_reply": "2026-05-14T05:21:38.110393Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rows in NYC bounding box: 48894 / 48895\n",
+      "Rows outside (would be dropped): 1\n"
+     ]
+    }
+   ],
    "source": [
     "in_bounds = df['longitude'].between(-74.25, -73.50) & df['latitude'].between(40.5, 41.2)\n",
     "print(f\"Rows in NYC bounding box: {in_bounds.sum()} / {len(df)}\")\n",
@@ -221,10 +807,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "geo-scatter",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:38.112567Z",
+     "iopub.status.busy": "2026-05-14T05:21:38.112455Z",
+     "iopub.status.idle": "2026-05-14T05:21:38.226841Z",
+     "shell.execute_reply": "2026-05-14T05:21:38.225998Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArwAAAIjCAYAAADhisjVAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzsvQeYJAd17X+qqqtzmDyzeVcBRYRQJCNykAMCY56Nn43Mg79NMMkYg58NfGCDHwZjG7AAG+EABoMJNjZgwAiRJIQCCBQ3p8kznbsr/79ze3p2ZjSzO7M7u9Mze3/6WtvTXV1dXZ1O3zr3XCOKogiKoiiKoiiKskEx13oDFEVRFEVRFOV0ooJXURRFURRF2dCo4FUURVEURVE2NCp4FUVRFEVRlA2NCl5FURRFURRlQ6OCV1EURVEURdnQqOBVFEVRFEVRNjQqeBVFURRFUZQNjQpeRVEURVEUZUOjgldRTpL9+/fDMAx88pOfXJV9eMstt8j6+O+Zho+B983H1Kns3LkTL3vZy9Z6M5Rlvi/+4i/+Yl3uq3e84x2y/Z3w2uvEfRmGIS699FL86Z/+6Rm5v+uuu05Obe677z7EYjH87Gc/OyP3r2wcVPAqynEE4I9//ONV3z8f+chHVk0kbzR+8IMfiOAoFotrvSnrRpgNDg6iXq8/4nqKtF/4hV+Q85/5zGdk2Y9+9KOLrut3f/d3Yds2fvKTn8xe9sUvfhHPe97z0NfXh3g8js2bN+NXf/VX8T//8z+n8VEpnc6//Mu/4NChQ3jNa16zJvd/8cUX4/rrr8ef/MmfrMn9K+sXFbyKcpLs2LEDjUYD//t//+9VEbxPecpTZH3892wWvO985zsXFbwPPvggPv7xj6/JdnUyY2Nj+Nu//dvjLvO//tf/wnOf+1z84R/+IUZHR+dd96Mf/Qgf+9jH8IY3vAGPecxjEEURbrzxRrzwhS+UZd/4xjfipptuwqtf/Wrs3bsXz3jGM+R5OpvQ194x3ve+98nrqVAorNnz8Tu/8zvyg2zPnj1rtg3K+kMFr6KcJKyYJZNJWJa1Om9G05T18V/lkSQSCalCKvO5/PLLRYTwx9LxoCh2XVeEbZsgCPD//X//H7Zv3y4VY/L+979ffpC9/vWvx5133om3ve1t+O3f/m380R/9kRzx+Md//Ec5pHw2oa+9FnfffbccBWCl/0TUarXT9nw885nPRHd3N/7hH/7htN2HsvHQb1ZFWUUP78jIiFTHtm7dKl+SmzZtwi//8i/PemN5mPnnP/85vvOd78hteWr70xbz8PI6+uXoW3va056GdDqNLVu24P/9v//3iO05cOAAfumXfgmZTAYDAwMibL7+9a+fki+Y1ehLLrlEHgsPabPKt1j19fbbb8fzn/98+RLi/V922WX4q7/6q9nrf/rTn4oH8pxzzhFRPzQ0JCJqcnJydhkKrje/+c1yfteuXbP7Z+6+W+ijZMXxxS9+MXp6emTfPO5xj8N//ud/zlumvV//9V//VXyHfG64DaxU7t69e96yDz/8MF70ohfJ9nEZLstqVqlUWnIf8dBuNptd1Fbwa7/2a7IuCktCwfic5zxHbAKpVEoeJ/fDqcBDu6zEnqjKy/3HfcxD0t/4xjfksr/+67/GPffcI7fl/qNofs973oMLL7xQfKMLvayERzSuueaaZW3bX/7lX8qRED7Wpz71qYv6LmmRePKTnyyvm66uLnm/3H///fOW4fPO7V+O35Z/8zn50pe+JO8dvnb5Gv7a1772iNt/73vfw9VXXy3P9bnnnruk5WPha69tefr+978vFfD+/n7Z/htuuAHj4+OP8LxyO/n+4T7m+5jv55X6gldjX958882y3Z/4xCfm3e7P/uzP5PL/+q//Ou42cJ/S3rLwKFT7eeDj+vVf/3X5HHjSk540e/0///M/48orr5Rt53uV7ynaIhbCIw18HrgcX2Pf/e53F90O/vDlZ+OXv/zl426voszl7PqZriinGYolCtrXvva18oXGw80UFwcPHpS/P/jBD8p1FEismBF6MI/H9PS0HI7mIWZWVj7/+c/jLW95Cx796EeLx7JdTXn605+O4eFhvO51rxOR9elPfxrf/va3T/qx8EuM9gJWU+jx5GFdCqM77rhDvujb1VY+PnpFKe7b980v2a985Svyd3sZilP+GOD13Ef8cuO/t912m3xZ8vE99NBDIsj45U5RSCgmFoMi7wlPeIIIzd/7vd9Db2+vVHwo+rmPKD7m8t73vleq57//+78vApY/Gl760peKWCesflKMOo4jzxG388iRI/I4KPKXOoT7kpe8BB/+8IdFaFN8t+F2/cd//IeIGh4F4Gvh2c9+tjweWgsoSCjmv/CFL+BUoMDhc8/Hw+eJYmEp+CPoU5/6lCxHAUix3LY7tAXg1NSUVHdP9cgFK8GVSkV+JDWbTfkBxO289957Z1/z3/zmN+U1zB9CfL1RcP/N3/wNnvjEJ+Kuu+5aVOQuBz4O7tdXvepVyOVyIuz53uT7kK8Twu1oPx+8b9/38fa3v/2E78e58HVCccfb8bnk+5ti+7Of/ezsMm9961vlufnFX/xFeX2xQsp/uU/O9L7k+4/7hSL9Wc96FrZt2ybr4Pv85S9/ufxoPR60svBHxFJHWvj6P//880VA0xpD+CPzj//4j+Wz6//8n/8jPwi4XRTNrBjzfUD+/u//Xo428D3N1x8/L/hepkDmdi6EApqCt1wuI5/PL3tfKmcxkaIoj+Dmm2/mp3V0xx13LLl39u3bJ8twWTI9PS1/v+997zvuHr3kkkuipz71qY+4/Nvf/rbcnv+24XK87B//8R9nL3McJxoaGope9KIXzV72/ve/X5b70pe+NHtZo9GILrzwwkes83iPl4+JjI2NRfF4PHr2s58dBUEwu9yHPvQhWe4Tn/iE/O37frRr165ox44d8vjnEobh7Pl6vf6I+/yXf/kXWdett946exn33dztmAvv47d+67dm/379618vy373u9+dvaxSqcj27Ny5c3a72/v1oosukn3X5q/+6q/k8nvvvVf+vvvuu+Xvz33uc9FK4OPcsmXLvOeD/Ou//uu8x/fFL37xhK+plfD2t79d1jc+Ph595zvfkfMf+MAH5u2v66+//hG3u/322yPTNKOenp6oq6srGhkZecQ+4baeLO33RSqVig4fPjzvfnn5G97whtnLLr/88mhgYCCanJycvewnP/mJbN9v/uZvzl7G552PZ6l9MBf+zdfu7t27562Tl//N3/zN7GUveMELomQyGR04cGD2svvuuy+yLOsR61z42mu/X575zGfOe53zsfH2xWJR/ua+jcVicl9zecc73iG3n7vOM7Uvh4eH5bl/1rOeJe+Hxz72sdH27dujUqkUnYitW7c+4nU+93n4tV/7tXmX79+/X/bHn/7pn867nO857pf25a7ryrbzMcx9j37sYx+T9S72efnpT39aruO+UJTloJYGRVklWFnj4T4eQmdVdrVgNfg3fuM3Zv/mffBwHysgbVito9WBFZE2PEz7ile84qTuk9UiVjxZaZnrKeb6WE1p2wZYodm3b58s167UtJl7qHlu1ZEVqomJCbEfEFafTgYefuV+mHvolPvqla98pVTbeHh1Lqxucd/NrYyS9n5sV3BpA1nMnrAUfJysbHF7qtXq7OWs8vE5aW9fe/+wYux5HlYTVst4qJyVxBN5ebnP2PTDSi7tC3MrmqyWEVZFT5UXvOAF8vjn3u+11147e9icRyNop2AFnFW8NrTDsPp4osPrx4NHJXhofO46+bptP9e0mPB55jbSv9zmoosukurrcuFrbe7rnK8prpv2IvKtb31LKsesNC+sDK/VvuSRCx6R4FEXbi9vR4vDcqqktCCxor0UfF3NhdVkWjpY3eV7vn3iNrAS3D4CRasPj4Dw9nPfo3w8Sx1ZaW8H16coy0EFr6KsEvQK/vmf/zm++tWvioigCKEAoa/3VKCPdKFPkR/2c0U1v2D5Bb9wufPOO++k7rP9hX3BBRfMu5xfRjxk2r6+3SXNw5zHg+KK9gbuF4pfHkamf5Uczx97om1cuH1t0TL3MbSZK2zmfmG29yO3h4d6/+7v/k7sFBQ+FAbL2T7aGig0//3f/13+pvClyKAQbj8n9F3ysDoPH3P99FfSU0kLxWrAw9h8rTFR4UTQt0quuuqqeZe3RQ8Pn58qFDQLedSjHjXryV7qNdZ+DilkTrbxaeFzvfA9w8PqfL4W28bFtme597PwNdV+jAvfhxSlxxOOp3tf0sbCaC8mdPBHLP3sy6VtVViM9nt6rieey3P7+Z6fe6LtiSJ37vYvfJy0TvDz5njbsZjPXFEWQwWvoqwirHTSh8rKGSus9K7xC4eV0JNlKS/l8b54Og1WeBgpxgoOqz7//d//PdtExArQmWA5+5EJBWywYzIBBRG9wWx4Onz48HHXzWo1PZJsjCP07vL2FMJt+MVMb/EPf/hD8XnSH8yGNXoR51aGTxb+wGIjz3KqvEvBZjVCX2cnsZSoaTcDrtV7Zr2+N1mpbWeM80jIct+D9D8f7+jVQv8418vnju91VpQXnpZqElwO7e1oe/0V5USo4FWUVYaV1je96U0i6thJTWsAhVSb01GRYPc2q60Lv2gXphCsZH2EjWpz4WOhhaF9ffuw8fGmHvGLiYd22ajF6iabyXiYdbHKzUr2Dbdh4faRBx54YN5jWClsBvy///f/4tZbb5UucQrT5VRNKer5xU5bAO0MFMBt28ZceBkbeSg42EDGxj0OhljNKu/JCgnaL1h5ZOPgUmJyubC6txD+GGw3oi31Gms/hxQyTBsg3KbF0kEWVvGXCyuMFGeLbeNi23OytB/jwvchBedKbE+ruS8Jm99YxecPczb4sdluuT+I+P5fLvx84GcSK7+0mSw8td8f7e1f+Dhp/Vnq/ng57VasdCvKclDBqyirBH2fCzuv+YFPP+Tcw9b84lntSWI8/E5h1j6kTrgtJzuogV9GtC+wu32uiGYnNQ/x83AoueKKK+TLjF+YCx9T+3btKthCMb7Yl2z7S3k5+4cd5Twky4ppGx62ZfoDhQAnMq0EClX6LReKX36pLsd2wGoul2NSBIXvwqxSCpyF+4AZumTu+vnD5WQD9WmbYJWX1pqVpAC0YWwWE0B4uJn/LlapZMQU9/uJYIQVX5NteBsmYrSTRZjqwcfP/TX3+eaPJ/5YnJsYwPcRX3esvrehb5XDB04Gvib5nuE2MrmhDR83vb2rBa0CzCxeGBn3oQ99aEXrWc19yaMM/EHG1BL+CKW9gT/wKKBPxOMf/3hZ53JtOExe4b7mD92FryX+3Y4lpLWGP0L4w5I/qufGvy31WcCMaB59WcsBGMr6QmPJFOU4sJljsfzOdtzWXPiFwS84Ch2KLX7R8QuZ8Vn8UmnDQ9j8Anz3u98t3j5m5jJi6FRgnA+/RJn7ym3jFyCrh7RVnExVmV8+jFPiFxUjq9gMx+oRc3np/2w30VEM8rEwcolfuGwM432zqsTKJcUDfaFtPzMrNmy+4ZfwYpUb7hvCyDbuM3r4uO651ak2/LJmJZJf+rQe0BfJL3yu99/+7d9WPMCDGaa0GtB3y6oRxe8//dM/yRc2vbcnguKfzye3nYJgrp2BcNu4/1jhpoBjhY0/SLh/5gqStp+y7c9cKYzIYgPbycIsZD53PCrBpqJf+ZVfkSYjVo4pvCi2ljNpjfuCFWNGoHF/8AcOD4n/wR/8wewyHJjB549CirFY7Sgtipj2IAzC1wIFOPcdn2v+uOTrjs/TyTY98rXN9zYbt9hUxueb900RNVdYnwr0rPP9yH3J9xDfS4wlo8+fVdflvi9Xa1/SM8t18PXRHg3Mzw0+z2wQY7X3eO8b+s7f9a53SY44I91OBF/n/JzjZwlfz2y+YwGA71F+NrLpjzGBfJ9zOX6O8bOQ7x0uQ4/7YkeC+DnCbVjYDKgox2VZWQ6KcpbRjh1a6nTo0KFHxJJNTExEr371qyUKLJPJRIVCIbr22mslnmoujCpiXFQul5sXubNULBljzBayWEzT3r17Zb2MMOrv74/e9KY3Rf/2b/8m67ztttuW9XgXxoExhoyPx7btaHBwMPrd3/3dR8SPke9973sSc8THxMd+2WWXzYuAYqTSDTfcIDFY3C8vfvGLo6NHj8p9MtJoLu9617sk5otxSnO3aWE0FNmzZ0/0K7/yK7JeRkxdc8010Ve+8pV5y7T368K4sYXPH/ffb//2b0fnnnuurIvRTU972tOib37zm9Fy+aM/+iNZ53nnnfeI6+666y6JbWIEVCKRkBimX/iFX4h+/OMfz1uOj3OxCK7jxZItpB1nt1gs2XJj9z7/+c9LLB33AyOkNm3aFL3kJS+JbrnlluNuV3u/MmKOcXnbtm2Tx/vkJz9ZYrIWwv37xCc+UV63+Xw++sVf/EWJB1vIf//3f0eXXnqpRI5dcMEF0T//8z8vGUvG9+FCFnv9MM7tyiuvlHWec8450U033bToOpeKJVu4/xZ7DzO674//+I8lSpCP8elPf3p0//33R729vdHv/M7vnNF9+cIXvlDeo4wLm8uXv/xluZ8///M/j04E39svf/nLl/1aJPwcetKTniSfDTzxM4XP0YMPPjhvuY985CMSK8jHeNVVV0mkH1/LC2PJvvrVr8r9PfzwwyfcXkVpY/B/x5fEiqKsV1gJ4rABNl3NjTVSFGXt4GF6+pJZ1WwPoFkv8KgHPcC0giyMIjxTsFLM6vjJWlqUsxP18CrKBmFhZz49nGxeYtSPil1FWRsWS8xo+9fbY8XXE5xOyDg2RvatBe0pjrRWKMpKUA+vomwQ2CDCLyJ6adngw+Yiemnp5VUUZW1ggxibr+jT5mAU+mTpPacHlmN/1xv0+B4vleV0w5jHhc2lirIcVPAqygaBXeccmkCBy0gpNs4x7mph85SiKGcOTjtjAyubNpkE0m5ko51BUZQzh3p4FUVRFEVRlA2NengVRVEURVGUDY0KXkVRFEVRFGVDox7eReD876NHj0pA9ukYA6soiqIoiqKcGkzW5RCfzZs3n3DYkAreRaDY3bZt2yk+DYqiKIqiKMrp5tChQ9i6detxl1HBuwis7LZ3IMd+nlaCALj77tb5xz6WQ95P7/0piqIoiqJsAD3D5BMWKNu67Xio4F2Eto2BYve0C17XBW69tXX+SU8C4vHTe3+KoiiKoigbSM8sx36qTWuKoiiKoijKhkYFr6IoiqIoirKhUcGrKIqiKIqibGhU8CqKoiiKoigbGhW8iqIoiqIoyoZGBa+iKIqiKIqyodFYsrUmFgN+/dePnVcURVEURVlvxDpbz3TeFp1tcBTeox611luhKIqiKIqyYfWMWhoURVEURVGUDY1WeDthFN+997bOP/rROlpYURRFUZT1R9DZekYFbye8QL70pdb5iy/uuBeIoiiKoijKetczamlQFEVRFEVRNjQqeBVFURRFUZQNjQpeRVEURVEUZUPTMYL3ve99LwzDwOtf//rZyz72sY/huuuuQz6fl+uKxeIJ1/Oe97wHV199NXK5HAYGBvCCF7wADz744GneekVRFEVRFKVT6QjBe8cdd+CjH/0oLrvssnmX1+t1PPe5z8Xb3va2Za/rO9/5Dl796lfjtttuwze+8Q14nodnP/vZqNVqp2HLFUVRFEVRlE5nzVMaqtUqXvrSl+LjH/843v3ud8+7rl3tveWWW5a9vq997Wvz/v7kJz8pld4777wTT3nKU1a2ca7bOi0Wrjx3ishiy7QxDMC2l16Wf7OzkXgeEI8fu45/R9Hy1rtay5LlbsPCZX0fCMPVWZbby+0+nctyv7f3/akuy9cDXxedsiz3AffFUrB7tt1B2wnL8jXG19pqLDv3/Xm6lj3R+341PyOOt6x+RrT2g35GtPaDfka09oN+RqzNZ4Q7R8/M5XTqiON9Xnaa4GU19vrrr8czn/nMRwje1aBUKsm/PT09Sy7jOI6c2pTL5daZ978fSCQeeYPzzwde+tJjf7/vfUt/Ue7cCbzsZcf+/uAHWbo+9jdfBJOTrfP/9E/A7/zOses+/GFgKRtHfz933rG/P/YxYHx88WW7uvjr4djfN98MHD26+LLpNPAHf3Ds7099Cti/f/Fl+eL/oz869vdnPws8/DCW5B3vOHb+C18A7rtv6WVZ1W+/sL/yFeCee5Ze9s1vBjKZ1vmvf52HDJZelvuB+4N861vAD36w9LKvehUwMNA6/93v8pfX0su+4hXAli2t87fdBnzjG0svy9cDXxfkzjuB//qvpZflmMb25BrmG7YjXxbjxS8GLrmkdf7++4HPfW7pZV/wAuDyy1vnd+8GPv3ppZd9/vOBa65pnT94kL8il172Wc8CnvjE1vnhYeDjH1962euua50IX7sf+cjSyz7hCcCzn906z/c030dLcfXVwPXXt87zvcb351JwH3BfEL6H/+zPll6WMTu/+qvH/j7esqv5GTGXzZuBV77y2N/6GdHaD/oZ0doP+hnR2g/6GbE2nxHRjJ5Jpeb/4D+dOuLuu7EuBO9nPvMZ3HXXXWJpOB2EYShV4ic+8Ym49NJLj+v7fec734k1gb+a2qKqXZ1TFEVRFEVZTxgzeoaFsw7UM0YUHa/OfPo4dOgQrrrqKvHZtr27bFC7/PLL8cEF1RtaGp72tKdhenoaXe3q3DL43d/9XXz1q1/F9773PWzdunVFFd5t27ahND4uDXOPQA9XHkMtDS3U0tBCLQ36GbEQ/YzQz4i56GeEfkas4mdEuVhEob9fjuYvqtc6QfB+6Utfwg033ABrziSOIAgkjcE0TRGg7etORvC+5jWvwZe//GXceuut2LVr14q2jYK3UCgsaweeMnxiefiZXHRRR/4qUhRFURRF6TQ9sxK9tmaWhmc84xm4tz1zeYYbb7wRF154Id7ylrfME8Irgfr9ta99Lb74xS+KUF6p2D3j8NdM22s517eqKIqiKIqyXvA7W8+smeBlTu5CX20mk0Fvb+/s5SMjI3LazaYa8ePfK7fbvn37bBMahTMrxazotpvgPv3pT0t1l8vy9oS/AFI0UiuKoiiKoihnFR19/Pymm27CYx/7WLyCHfCAxIrx73//93+fXWbPnj2YmJiY/ftv//ZvpbRNP/CmTZtmT59l55+iKIqiKIpy1rHmsWRzWZi3+453vENOx2P/gqiLNbIkK4qiKIqiKB1KR1d4FUVRFEVRFOVUUcGrKIqiKIqibGhU8CqKoiiKoigbmo7y8J6VMH6tPdr0JKPYFEVRFEVR1hSrs/WMCt61hi+Kyy9f661QFEVRFEXZsHpGLQ2KoiiKoijKhkYrvJ0wim9msAbOO09HCyuKoiiKsv4IO1vPdNbWnK2j+D796daJ5xVFURRFUdYbfmfrGRW8iqIoiqIoyoZGBa+iKIqiKIqyoVHBqyiKoiiKomxoVPAqiqIoiqIoGxoVvIqiKIqiKMqGRgWvoiiKoiiKsqHRHN5OmEzy/OcfO68oiqIoirLesDpbz6jgXWv4orjmmrXeCkVRFEVRlA2rZ9TSoCiKoiiKomxotMLbCaP4Dh5snd++veNG8SmKoiiKoqx3PdNZW3M2wvF7n/xk69SBo/gURVEURVHWu55RwasoiqIoiqJsaFTwKoqiKIqiKBsaFbyKoiiKoijKhkYFr6IoiqIoirKhUcGrKIqiKIqibGhU8CqKoiiKoigbGs3h7YTJJM961rHziqIoiqIo6w2rs/WMCt61hi+KJz5xrbdCURRFURRlw+oZtTQoiqIoiqIoGxqt8HbCKL7h4db5TZs6bhSfoiiKoijKetcznbU1ZyMcv/fxj7dOHTiKT1EURVEUZb3rGRW8iqIoiqIoyoZGBa+iKIqiKIqyoVHBqyiKoiiKomxoVPAqiqIoiqIoGxoVvIqiKIqiKMqGRgWvoiiKoiiKsqHRHN5OmExy3XXHziuKoiiKoqw3rM7WMyp4O+kFoiiKoiiKsh6xOlvPqKVBURRFURRF2dBohXetiSJgfLx1vr8fMIy13iJFURRFUZQNpWe0wrvWeB7wkY+0TjyvKIqiKIqy3vA6W8+o4FUURVEURVE2NCp4FUVRFEVRlA2NCl5FURRFURRlQ6OCV1EURVEURdnQqOBVFEVRFEVRNjQqeBVFURRFUZQNjebwdsJkkic84dh5RVEURVGU9YbV2XpGBe9awxfFs5+91luhKIqiKIqyYfVMx1ga3vve98IwDLz+9a+fvexjH/sYrrvuOuTzebmuWCyecD233norfvEXfxGbN2+W23zpS186zVuuKIqiKIqidDIdIXjvuOMOfPSjH8Vll1027/J6vY7nPve5eNvb3rbsddVqNTzmMY/Bhz/8YaybUXwU8jzxvKIoiqIoynoj6mw9s+aWhmq1ipe+9KX4+Mc/jne/+93zrmtXe2+55ZZlr+95z3uenNYNHL/3wQ+2zlPYx+NrvUWKoiiKoigbSs+seYX31a9+Na6//no885nPXLNtcBwH5XJ53klRFEVRFEXZGKxphfczn/kM7rrrLrE0rCXvec978M53vnNNt0FRFEVRFEXZYBXeQ4cO4XWvex0+9alPIZlMYi1561vfilKpNHvitimKoiiKoigbgzWr8N55550YGxvDFVdcMXtZEASSsvChD31IbAbWGcpxSyQSclIURVEURVE2HmsmeJ/xjGfg3nvvnXfZjTfeiAsvvBBvectbzpjYVRRFURRFUTY2ayZ4c7kcLr300nmXZTIZ9Pb2zl4+MjIip927d8vfFMi83fbt29HT0zMrnG+44Qa85jWvmU19aC9P9u3bh3vuuUeW5+0URVEURVGUs4s1jyU7HjfddNO8ZrKnPOUp8u/NN9+Ml73sZXJ+z549mJiYmF3mxz/+MZ72tKfN/v3GN75R/v2t3/otfPKTn0THYZrA1VcfO68oiqIoirLeMDtbzxhR1IHpwGsMY8kKhYI0sHHKm6IoiqIoirJ+9VrnSXBFURRFURRFOVssDWcFLLDX663z6TRgGGu9RYqiKIqiKBtKz2iFtxNG8b3vfa0TzyuKoiiKoqw3vM7WMyp4FUVRFEVRlA2NCl5FURRFURRlQ6OCV1EURVEURdnQqOBVFEVRFEVRNjQqeBVFURRFUZQNjQpeRVEURVEUZUOjObxrDcfvXX75sfOKoiiKoijrDbOz9YwK3rUmFgNe8IK13gpFURRFUZQNq2c6T4IriqIoiqIoyiqiFd5OGMXXnkhi2x03ik9RFEVRFGW96xmt8K41fHH82Z+1Th04ik9RFEVRFGW96xkVvIqiKIqiKMqGRgWvoiiKoiiKsqFRwasoiqIoiqJsaFTwKoqiKIqiKBsaFbyKoiiKoijKhkYFr6IoiqIoirKh0RzetYbj9y6++Nh5RVEURVGU9YbZ2XrGiCImBStzKZfLKBQKKJVKyOfzunMURVEURVHWsV7rPAmuKIqiKIqiKKuICl5FURRFURRlQ6Me3rXGdVtj+Mjb3gbE42u9RYqiKIqiKBtKz2iFV1EURVEURdnQqOBVFEVRFEVRNjQqeBVFURRFUZQNjQpeRVEURVEUZUOjgldRFEVRFEXZ0KjgVRRFURRFUTY0Gku21nD83vnnHzuvKIqiKIqy3jA7W8/oaOFF0NHCiqIoiqIonY2OFlYURVEURVGUGTqv5qwoiqIoiqIoq4h6eDthFN/73tc6/+Y3d9woPkVRFEVRlPWuZ1TwdgKet9ZboCiKoiiKsmH1jFoaFEVRFEVRlA2NCl5FURRFURRlQ6OCV1EURVEURdnQqOBVFEVRFEVRNjQqeBVFURRFUZQNjaY0rDWGAezceey8oiiKoijKesPobD2jo4UXQUcLK4qiKIqidDY6WlhRFEVRFEVRZlAPr6IoiqIoirKhUQ9vJ4zi++AHW+df//qOG8WnKIqiKIqy3vWMCt5OoF5f6y1QFEVRFEXZsHpGLQ2KoiiKoijKhqZjBO973/teGIaB17MMPsPHPvYxXHfddcjn83JdsVhc1ro+/OEPY+fOnUgmk7j22mvxox/96DRuuaIoiqIoitLJdITgveOOO/DRj34Ul1122bzL6/U6nvvc5+Jtb3vbstf12c9+Fm984xvx9re/HXfddRce85jH4DnPeQ7GxsZOw5YriqIoiqIonc6aC95qtYqXvvSl+PjHP47u7u5517Ha+4d/+Id43OMet+z1feADH8ArXvEK3Hjjjbj44otx0003IZ1O4xOf+MRp2HpFURRFURSl01lzwfvqV78a119/PZ75zGee8rpc18Wdd945b12macrfP/zhD5e8neM4El4896QoiqIoiqJsDNY0peEzn/mM2A5oaVgNJiYmEAQBBgcH513Ovx944IElb/ee97wH73znO7EmcPze5s3HziuKoiiKoqw3jM7WM2smeA8dOoTXve51+MY3viHNZWvJW9/6VvH9tmGFd9u2bWfmzm0beOUrz8x9KYqiKIqinIV6Zs0EL60HbCS74oorZi9jdfbWW2/Fhz70IbEZWJa1onX29fXJbUZHR+ddzr+HhoaWvF0ikZCToiiKoiiKsvFYMw/vM57xDNx777245557Zk9XXXWVNLDx/ErFLonH47jyyivxrW99a/ayMAzl78c//vGr/AgURVEURVGU9cCaVXhzuRwuvfTSeZdlMhn09vbOXj4yMiKn3bt3y98UyLzd9u3b0dPTMyucb7jhBrzmNa+Rv2lN+K3f+i0Rz9dccw0++MEPolarSWpDR+J5DA5unX/1q1uHBBRFURRFUdYTXmfrmY4eLcxIsbnNZE95ylPk35tvvhkve9nL5PyePXukWa3NS17yEoyPj+NP/uRPRCxffvnl+NrXvvaIRraOIYqA9kANnlcURVEURVlvRJ2tZ4wo6sCtWmPYtFYoFFAqlWTK22nFdYE/+7PWeQ7YiMdP7/0piqIoiqJsAD2zEr225jm8iqIoiqIoinI6UcGrKIqiKIqibGhU8CqKoiiKoigbGhW8iqIoiqIoyoamo1Mazgo4fq+//9h5RVEURVGU9YbR2XpGUxrWOqVBURRFURRFWTGa0qAoiqIoiqIoM6iHV1EURVEURdnQqIe3E0bxfexjrfOvfGXHjeJTFEVRFEVZ73pGBe9aw0F34+PHziuKoiiKoqw3os7WM2ppUBRFURRFUTY0KngVRVEURVGUDY0KXkVRFEVRFGVDo4JXURRFURRF2dCo4FUURVEURVE2NJrSsNZw/F5X17HziqIoiqIo6w2js/WMjhZeBB0trCiKoiiK0tnoaGFFURRFURRFmUE9vIqiKIqiKMqGRj28nTCK7+abW+dvvLHjRvEpiqIoiqKsdz2jgnet4fi9o0ePnVcURVEURVlvRJ2tZ9TSoCiKoiiKomxoVPAqiqIoiqIoGxoVvIqiKIqiKMqGRgWvoiiKoiiKsqFRwasoiqIoiqJsaDSloRNIp9d6CxRFURRFUTasntHRwougo4UVRVEURVE6Gx0trCiKoiiKoigzqIdXURRFURRF2dCoh7cTRvF96lOt8y99aceN4lMURVEURVnvekYF71rD8Xv79x87ryiKoiiKst6IOlvPqKVBURRFURRF2dCo4FUURVEURVE2NCp4FUVRFEVRlA2NCl5FURRFURRlQ6OCV1EURVEURdnQaEpDJ9Bh0R2KoiiKoigbSc/oaOFF0NHCiqIoiqIonY2OFlYURVEURVGUGdTDqyiKoiiKomxo1MO71vg+8NnPts6/5CVATJ8SRVEURVHWGX5n65nO2pqzkTAEHn742HlFURRFUZT1RtjZekYFr6Ioyjqi6frwwgi2aSAZ149wRVGU5aCfloqiKB2CH4QIogiWYSBmPbLFotpwcaTUlOXSiRg25ZMqehVFUZaBNq0piqJ0ABSxFcdHueHJv/x74fXTDQ9TNQe2ZaLutCq9iqIoyolRwasoitIBsLJLUZuKx+Rfxw9Qczw5tSu/BiLkUzYma45UgGlrUBRFUU6MWhoURVE6gLaNoeH6gAFUGh6qbgBEEQqZOHLxGDLJuCybT9roTtlqZ1AURVkmKngVRVE6AIrdXCI2W+kt+gFirOAaBlwvRGBHiFsG4pkEEjFrUY/v6fYQL3X9iW6nKIqy1nTMJ9N73/teGIaB17/+9bOXNZtNvPrVr0Zvby+y2Sxe9KIXYXR09Ljr4fUve9nLsHnzZqTTaTz3uc/Fw+2YjE4kHgfe8Y7WiecVRTlroVikmJWTZcHxQ9SbPkIjRMMNUHcDuEG0Zh7iYt3FRLUp/zItgrYL/tu+HS9vWzAURTnLiHe2nukIwXvHHXfgox/9KC677LJ5l7/hDW/Af/zHf+Bzn/scvvOd7+Do0aN44QtfuOR6oijCC17wAuzduxdf/vKXcffdd2PHjh145jOfiVqtdgYeiaIoysnT9u6SbCKGbMJCJmnBc1pi05hTTT3dHuKF98HtKjY8eH6EyZorPmKK3FLTQ9PzpZGO1xfriwtmRVGUs1rwVqtVvPSlL8XHP/5xdHd3z15eKpXw93//9/jABz6Apz/96bjyyitx88034wc/+AFuu+22RdfFSi6v+9u//VtcffXVuOCCC+R8o9HAv/zLv5zBR6UoinJqFVYKznjMQiZuY6LmYbTUxIHJOoIgFOvAat1nuzHO8wK4foDJakOE9aL3QRFsQLbBD1vimIUG0zBRcz25PpNYXDAriqKc1YKXloXrr79eqrBzufPOO+F53rzLL7zwQmzfvh0//OEPF12X4zjybzKZnL3MNE0kEgl873vfW3IbeLtyuTzvdEZH8f3rv7ZOPK8oylnJwgpr2+JQcTwEYYjBrhRoj03YJ+/fFfsBK7KuL5m+h6br2D9ZkX8PTlYxXnFRqXvwomPVWS47XXPgeAEyqRhs00R3Li5CnA12CTuGQjKGrlRcmuu8IJTtWy1RrijKOsHvbD2zpk1rn/nMZ3DXXXeJpWEhIyMjiMfj6Orqmnf54OCgXLcYbUH81re+VSwSmUwGf/mXf4nDhw9jeHh4ye14z3veg3e+851YEzh+7777Wudf8IK12QZFUToqpeGYlxdoOC4838f+8Qp6M/GTjiKjcB0uN0W4mojECzxVd2GZBjKJCKVagGTcgGnbaDR9VCwPURhhvOZgvOwgiEIM5lLozsYQtyh8Ddi2NStsAz9AwjRhWcZpa6pTFKWDCTtbz6zZJ9KhQ4fwute9Dp/61KfmVWRPBdu28YUvfAEPPfQQenp6pGnt29/+Np73vOdJpXcpKJBpoWifuG2KoihrkdLAnF3+y7+lUazho9Tw4foRPADGSQpeDqmg2O3OJFBxAjS9AP3ZJGqOj6YbIS4pEDGxN7A5bqzcwL7JOh4eLWOk0sCesTJ+PlzEQ8NVHJysycQ3xw1kG8drTdw/XMJ9w2WMlxurvm8URVHWbYWXloWxsTFcccUVs5cFQYBbb70VH/rQh/D1r38druuiWCzOq/IyhWFoaGjJ9dLre88994hw5e37+/tx7bXX4qqrrlryNrQ88KQoirKWUOTGFojUctOHFTMkrcF1rZNuBmNFlnYI2hNyCQuRYYoXd1t3WirHgQGJPwsjG1EUIooMuKGLyXIDh4sN5JIJIGzZIXb05TBaborVghXi8UoDR6eb4gEuNRLIJ+PoySVnvbysFFOoa2yZoihnneB9xjOegXvvvXfeZTfeeKPYEt7ylrdg27ZtUrH91re+JXFk5MEHH8TBgwfx+Mc//oTrLxQKs41sP/7xj/Gud73rND0SRVGU04PBxq8oEl9tOsnUhvhJWwWS8Rg25ZMiotu2iPZ5XjdXnFZcHxPlJsLQwLbeLGK2DT8IwEnGdSfAvrEKIkRImBTFtEZ4qDU9FFIJ1J0QjaBV+WXzneP5qDqtFIe4bSKfsNXyoCjK2SN4c7kcLr300nmX0XPLzN325S9/+cvxxje+UewJ+Xwer33ta0XsPu5xj5u9DQUyPbg33HCD/M0IM1Z16eWloKZtglFlz372s8/wI1QURVk+i1VD+W9vNoF03BRLQ3++NXTiZKGwnWsgm3tehDRj0aJQPL5dGRsJeooDG+l4DKwr+36EiueiXPfRaLg4Umlga1cGtukhk7DhhT66E3GpArfyeJngYGCq6iLHkciVJtxcAvlUYta2oSiKgrN90hobzui9ZYWXSQrPec5z8JGPfGTeMqz60r7Qhs1pFMm0PmzatAm/+Zu/iT/+4z9eg61XFEWZz2ITydrZuxwsUW16mK67sGMmChkbNkwZyJOIxdCbs9GbPvkK7/HgNpQaDsZLDmpeiKbnImnbYnXYlkvDyyfgBiHKdRfudIBCxkBfJomG5yMWA7b1ZFBIx+DQC5ww4AWQscgUzHUuYxkifhs+K8rm7H7o6C8gRVE2FB31eXPLLbfM+5vNbB/+8IfltBTMgJzL7/3e78lJURSlk2hPKis5LqzIRF82LhVXHvavOz5KdRdTdQcPDpfRk46jLxfHYHcaSctC1Y+Qipmy/OnYLjad7Rut4PB0XWwOnh9IFXa65uK8AfY5WKg1AzBqlxVmKzCRilvoy7MKzEa7GPqySRlCwdtkkzbomuAytkX/cYDpuicV5ErTR2/2WLqDoijKmeCkPz2/+93vSvTXnj178PnPfx5btmzBP/3TP2HXrl140pOetLpbuZGxbeBtbzt2XlGUDQmruGMVB9PVJspOgMFcXCwKYWTAsiCTyyh2m26IidCFz1xe34CPCGEQtNIUPB+FdMvWsFqVXlZaqw2uOxKP7nCpiWrdxVAhlNgylhR60jbSCRsx20A2stGfS8IJAsRMIGZa4s3l9hSS/AwzEEYhknZMRO14zcWRUgPVhoetvRkRwBTCamdQlA2G3dl65qQ+Mf/t3/5N7AWpVErG97YHPtBa8Gd/9mervY0bG1Y5OHOaJ614KMqGhpXTuhfCQISDU3U8NFLF3okKfnqgiAPjjPuq4mixht2jJYxXmhiv1lBruKj5Ae4bKeGeQ0XsGS9jtNKUwREU0QtTG9oWiROlObSX44Q13w8xxUEUkzWUag4ShoXpuoNe+nhjBqpOgIlqA9MVFwm7JdCzM81nhXQcVMVcFz3HHELRk2l5dOuuj4fHKhguNsT+MFqqz1g0Tt6HrChKh2J0tp45KcH77ne/GzfddJOMA2aSQpsnPvGJMkhCURRFmS8s2YyWTduIWxA/bCZuiQBmAsP+8Sommx4ma02pmrLS2pNOwjAsjNcdjEw1RCRSw1adEGOlJo6WGhIxRktEW9wuHE+8lOiduxw9uxwWMZRPoCsZQ8qykE5byCVtxAwTZsQ4MwM5+odpq7BjyCdpZQC8IEKx3pRxw/Qgc30N/9jo48m6i7FKQ2LLHhwpo1JzZWyxoijKurA0sFHsKU95yqJRYMzNVVYAx+995Sut87/wC5AOEEVRNgRzo7kaFJYAhrrSGPBDydcdqTgIgghOGCJgQ5cRkwpwJhFDGAUoVSgQTfTkmIEbSiU24PXZhJy3Y9a8BjD+y/vi5fw3TevAIuLb9UM0/QC5ZBzT9VaerutFcCMDRszEdM3DUCGB7kwcqbiNyAgwWXZkKAbTFyZrwETVQaURIJu0JMs3iDDvfgVpsTAwVnJk+61YDAEibVhTlI2I39l65qS2hoMfdu/ejZ07d867/Hvf+x7OOeec1dq2s2cU3z33tM4///lrvTWKoqwiFKAUmRSCjOZi0xn7bPPZBLpycSTsVgqDYQIj0w10ZxPY3J2SWLCmE2Ck4iJumai5PnYN5DCYSyKV5IG5CImYKRXixIxXltCeIFPZPEfWnY3HpDLMbaBQLTZcGWDhhxDfLeF0tVwSiPUYuO9IEeWah63dScQ52tiOiRjuySZQaYQilFnJ3T9VxYGxusSVZRMmEpYBOxaD67lIJUx0pVppEhxwyapu1XNhw8LhUg0XOTltWFOUjUjY2XrmpATvK17xCsm3/cQnPiEf1kePHsUPf/hD/P7v/75GgCmKoszQjh9zZqK5Gi6bzuKSYMBT3G6N8h0qpNGTTODCoVAsAWwIGys68CMDactCLQhFDA90JVF3Q9imhWSCo4iPDXEQUesFqDP/NoxEnE7HeT5EyfElA5cDImityCVjgGEhGUsiZVso1kMcma5jeLqJYq2Jhu/hMdt7YFtA06N1IUTGbglvPqbRogvXDVF1m0glsvADQ6azJeKWVKwp9JOWiYwdQ5YJDpmUxJHl4rbk8WrDmqIo60Lw/uEf/iHCMJRpafV6XewNHM1LwcvhEIqiKEprmAObt3iIn9VW+mWZYOBHIY6O17F7vILRYhPZZAz9hRS2d2fQFzNRbnrin903WUHDBPozccRNA44fiQeYVgOKUBlFPJPWQKtCiQ1ujo+xchO9mQRMGftLn62DphdiquJKLu7O/izyiTjisdbtA9Ci4KIeeNjSl8V01cFAzkY8FoNl+jI8opC20ZdPSVMdq7pJK4HxmofuFD29MXgRq8UmnLBlmUjEQklj2NGTkYEVTTfA+QNZ9KZ1jLuiKOtE8LKq+0d/9Ed485vfLNaGarWKiy++GNlsdvW3UFEUZR0OlFjsembpMue2XAlwYKomwvbAZBVb+3PIsnpqAQOFOLwwlNOWnhSGsmmZtra1N4VCMiF+37bYbVsZONlsotbEWLGBo8UmLDNC2fGRScYxUqnDdSNM1RwUaw66Mwk0PA+JuNlqhIs4DQ3Y3JVCMhaD44XY1J3G9t4cMgkLUWSJiDbN1pjjTQVuB/ODA1xgGtjRm0E+FZeMYY4QZgIF/cFwDKRiFs7bXEBPLiVN25sLSWRT8TV4hhRFOds5JUdxPB4XoasoinK2N6bx33ZFd+4UtemGK/7cB8dLqNc95NIJ8bhWGh5KdV9sCU7Dh9ENpBMxmIYpXlwT9PZamKw7MI0I0/U4+rMplGsOJis+0gkDcSvTmpLW9FGseghgIJekxcES0Xm0VJFBD44boOEE6ErGsbUng6RtSdJCe5wwkxcGulK4elePZP1uKaSlEa02UxVOJS14rg/DhjS60UssAyqCALbV8ghbMRORAzgB0DNjsTDiFvozSfSkE0v+GFAURekowfvCF75w2Sv9whe+cLLboyiKsi4b01LxmHh0ZZBDrSlJBzXPl+iw+46W8YOHx1FpukjbFq5/7DZ0p2wZH+wHWRGfW3taU9Wmqy6mam7LLxtCBHMmYeLQZFMaxn60ewKTVRf5TBzX7urF5p60xJzxxCquwRqrEcKIIOuguD7UbEgznM8kBcvEpkJCYsfIrEg3U7hsBxA3Y+LhdYJIhHcsFqFUccR0nE8ZcNkoZ5ozgzIq0tS2tTuDnpwtR//KDReGEWKwkJ4VuZ3Vq60oytnIsj+HGDk2d5zvF7/4RbnsqquuksvuvPNOiSRbiTBWFEVZ77AJjL7Yw1N1DJfqODBWxYHpGqbrLlzfh83pZRUHRyccZPMmJvwQDx8p4SkXbcJ5gxkkbEssBRzdy9G8MdNAjOkNJjBWZs6ui0Iqjihs4KHhIu48MIVcPIaRSlMsAoZlwKd/t8Y4slaIbyYeQ28ugYeGK4jFDPRnEtgxkIFlmBjMJtEzM9a4DUWpQbEeAKOVuojW4VgDccvAYD6Jcd+FIwkQLnpzcZRMHz87PI2HRiqwTFMSKC7b1i2C347TBhGJ51gruoqirDvBe/PNN8+ef8tb3oJf/dVfleETFk1nrHIEAV71qlchn8+fni3dqHBwx5vffOy8oijrBlZ26V3dPVzCLQ+O4bYHj2J/CfBmruenIx2rdNrWAVSmQ/SkxN6KQspCXzYpwpNJDaMlRxrPym6IrqQNzw2xpTuFSj2GZMwQWwMFMWIGhqsO0jELxaqDTYUMJpjny3uR8cChxIHFGha2dNEza8PoipBJ2sjEbXRxgMQCawGnto1WHJTrjlSRh8sNsVqU6o6IWfpv+/MpjBQbMlaYTXDjpbpYGugnLjY9lJsNVJoBEk4MfjImjWttm8dq+KAVRelw7M7WMyd1pIlxZMzcbYtdwvNvfOMb8YQnPAHve9/7VnMbNzb8Jslk1norFEU5CcS+4Pg4OF3H7Q8fxcOlBdcDaMyc56dldwLY3JPFJUM5FDIJGcXbFnv03EahIRXZ7mwcDS9Aj59AJmXDNiKYpoW41UDWMGGlLGzuSkvTGZvVaHtwQ6A7HUd3OoGh7rQ0jPXlbGSTrA5Hcl+LiUk2vB0pNWWUMZercnCFZWCk1EDEiLGwKZm/jDJL2TE0/RBdGW5XHEHVQdywkI2ZmKoHGC83UW746E3FZHrbdkTi4T2RgD2eD1pRlHWC0dl65qQEr+/7eOCBB3DBBRfMu5yXMa5MURRlo0Nx1hro4OLOPWN4aPr4y7PS25OzcPnWAs4dyEkebTtlgeKOObWGESEKDDSYm1t1MVFzkbEN9PVmxPPL0b6MGxsp1aXRrNwM4EcOdvRn4MhIXyCXiiNN0ZyLixXiRMKRzWd8HAO5pIjc3lSrwazmhAgtoDefhOdHiFk2Nndx8pqFphdgW1caFkxU6g5SCRu+56Nap0c5BocCtuFjdLopvmQZU7zEdvC+Ke6ZVUxx3vZBq+9XUZTV5KQ+U2688Ua8/OUvx549e3DNNdfIZbfffjve+973ynXKCkfxff3rrfPPeU7HjeJTFGXpiiQTDQ5O1LB7tHzC3bSzB3jmJdvw7EuHsLUnC1tydQM5cWKaFwYo1335m81uw5N1RKYJykSeDNPE5nxCbjdSdnCkVIPjRtjVl8X2vjSG8ikU0pyaZssEtExieQMeuD6mQ1QbHnoycaQTplgfOOhiZLomUWTn9KeRTsYkHo3Lc2SwaVkSbVZ2DEzWmzBCA8m4JWI9kYzB8X2MVyMk4yb8KEL3IuJ77n5kTjDgzpscpyjKOsLvbD1zUlvzF3/xFzJe+P3vfz+Gh4flsk2bNkku75ve9KbV3saNDSvid9zROv+sZ6311iiKsgwoSisNV/yu9x8tY7K69JEtSrdNCeDRuzbhql296Mkm5fZjDU8SDzh2OMEkA9PEtt4MHh4rS/NYxQvYEYc4vXChIYf5811JpOJN/PTwNBKejWzCQCbDymtG/L60UFCMhnKvS0OhyW0gFJfpONMXLDQ8H7tHq/CCCF2ZGM4fysK24pIPjMhAzfXQ2qwINu8iMuB6odguwiDAOQMFhGEkAy26sjYmyy6iyMB0pYmYwci0+SK8nXDBqDOKXYp0Tn5TO4OirEPCztYzJyV4TdPEH/zBH8ipXG5VNrRZTVGUjU7LwuBhrNTAw2MVPDxcxu37R1B0H7lsN4DeXkOyb8/bVMATdvVjE6PBwhBhyCptHbYZQzYBqfBy4EPdbaKQiCHygUKC/lwPgR9DOmWKr5YjhRMcKRyP4dBkFbXQwM4+E6mUBcukFSJAJhET4cq0h9SMXWLhY6Dnd6rShBuwBy4SO8RouYHRsoPDxQYGskn4vo1z+nLoz6XEcsDHzclrY+WGVIJ7cgm4YYCqa8swC8/3kU3E0J22ZVtCiuEExwwHqDgcO+yJx2+uP7ftKaaNgRaN0yl2tSlOUc5uTrnerEJXUZSNDhu7KPoOl+piYdg/XMHeqSoeGp3G/hFvNpVhLk+4qAdPv2QztnanJcqLDWWsnE7Wmhgtuag0PaTjEaYbDgIezjdMGdk71JOGYZiYqMVhWDF0Z5nvG4pvtuY2UG36GCik0ZdPSJTZRZu7YEQGjhYbmKp5CKNAkhhYgPXD6BENYKyq1h1aJ4Cq40r0WeAFGK03MDLFMce2VJ5DMyHlaS5v8GSYKDU5BKOVxTuQT6I3Z6MnHZeGOdsC8umEeIxFcBscnAHZXmYCU4i3RWf7i6fdoHa60xm0KU5RlJMSvLt27ZKA8aXYu3ev7llFUTaM2D1crOPgZA3fe3AcR0tl7BsrYaoKTDjiIHgE5/cAL7pqJ55wfv9s3i0tBBwMYRkWSnUXpmmgxOEUvofJiod8yoYbxpGt++LnNS0DddeDOzWTzWsY8KMQfbmUpCbw9kxLiMcMqTjvnazi6GRTIiJ39mVx3SXJRwhM0haWrNgW6z7uOziNkXIDAQJk7SRsO8RQMoYdXSkR0uPlBupuIPfXtivQxmCYAQoJGxduTkjjG0WxF0FiylitZYaveHfTCckk5nhi3u9kpSGpPhnbkjHDZ2IwxWLDQTrLXagoyunmpN7zr3/96+f97Xke7r77bnzta18TH6+iKMpGYbhcxz37p7B7pITvPzSMWi3AYWfp5elG7c9nkM+0KqsUuhSZPIURRPzRtxtFrOqGyMdtNOwQVceTqWUc2+u6ERzXR9MNJKKsWHORiMXksmLNl4JDOm4hk7Ak/uvoeA33HS7hwEQdXSmL04Jx/qYczhnIP6IBjNvUm46jnvdwZLKGittqkmMl1i6YOC+fwdW7erGlKy0DNWh7mKy5IlwpeGNWiL0TNVlPdyaOc/uykgyx0DZAknZLaBZSMZn6xnSJI1MNGayxKZ/CRUN5Eb2nG24Pt4g/DCSn2IhgpRLqFVaUs4iTEryve93rFr38wx/+MH784x+f6jYpiqJ0BIenK/jGvcP45r1H8MBwA+XFyrkLSPCD1TSl8YxDKZwgQMKyxN/K2DBWPmNmaxBEw7FQqbsS58jr+vMJbO5K4v6jRYxMN1BzIwRBE+cMZsEhavl8Auw1S9oUuqZUU3NJE6WGj0rdkzHGGTspgyeYmbtUni2rzgPZpCQxZOIxyfj1Ak8a5Jjty2oyt5vT1diYV2D1WRrsOP3NR7HhSToERTJHEGdn1ruwWtu2K7BKPl1zUWmEmKg52NKVwVi1ie1eBlkajc8ATIJgpb7S8MTysanLE/vFctMsFEVZ36zqUZ3nPe95eOtb3zpvKpuiKMp6hNPH7tozhW8/MIKfHG3gOEXdedC3OlTIiGd1surI6OCG60kjF/Xypu60VD0jmEhnIuRTcWztzUhDFyuPFJFHppuYrLc64VLxhMSMMcmAwx+Y1VtthpLby4SwMIpQyMQxVEjJ0Are/zlDWRHOxxNyFHrM7z1crKHpuSKcd/RlWQ7FwekGJpmvS9tB2kbc4n0xIi1CBA+bwhTGKk30ZxNIUKkvQVsAO24AP2RKUcSUM9Q8D32ZBOwzFD9G0V1jJZsRaH6Aw9N1sYs4PYFYRBaLTFMUZWOxqoL385//PHp6elZzlRsfRg61LSIdOIpPUc5WKJD2TFZxcLy6bLHLD9Rt/XFcurlbPK/FhotuIyHCNGKl0wslp9b1I8AIkE8nEQ98eIEJz/NZGsZ0leN8HUQmYy1DDBSSOKc/h4FCAslYDJTNNa819IJeXkk2iJlI2AZKlQx6sjE8ens3ujLJ42+rZWJTIYVrd/XhUYM5HJ6mwKVgp90iQNOlz9eVjN582paGOy8MpXIc7zIxFKXRm4md0JIgEWhSwQ6RsGI4fyCDVDyO3mxM1n0mYIwaq8yTNQfVhi/7kCKXIp5+5CCpnl5F2eh65qQ+bR772MfOa1rjB/nIyAjGx8fxkY98ZDW3b+PD/djVtdZboSjKApHGYQoPDE/jSH35u2ZTHrhqey/O6c+IGKUFouF5GCikpNIbNFwZRXxouoaudBINt4ZC2kYQRpiqu+hK2hivNmXSBEfycswvBS+XYcQl/cC0SyRjBkzbliEQHBm8KZdCVyoGquRMvNUMthxoX+AkNQpPbiMrzIcnGjgwVUelWcN5gzkR3fQeszrdzstNxmxpXuPtl6Lt55V/gxDxuA2/6kll25XJajFU3FYj2+murnI7WKXeXshg2KpjIBNH3I61mvBsUwddKMpZoGdOSvD+8i//8jzBy1ze/v5+XHfddbjwwgtXc/sURVHOKO0Iq4mKg5GpxrJuQxvqBYO2TFJ72kWDyLEpzA0wxKQDRMgnbLE17BmtYM9wGdNNHxdstiTiq+l6aPrAkemajAK2Y62oLtsycVl3Fx69rUtSDeg95SSzesMFS8bMz43oX4hCub4rZaMrs/JD84wMY+NbOh4Xw4Idc7GjN4P9k1VZp92efGYZknDA9VOgM1atavgozAyTmBst1t6HHBcsotcPUW/6iMUslBs+YEbIhjGJR8vz9jj98HuqJ2/DMNPSCCg2kURMMo3VzqAoG5+T+px5xzvesfpbcrbCzpZvfat1/hnP4DfPWm+RopzVtKuSnJLJprMT0WMCF+3I4cXX7MDjz+1DKmZLrBg9uzy1R+WWGqGM7+3KpmBZzVY0WRhhvOrC8yP4CEVIchrZ5Tu7YUSWjPTlZDbGmTEfd7rqcimkTGbaMrbMRSHNNrkIFcdDKt4a3HCiIQtzq6+s3HKUMKeoWZEhCRIxy8DWrhSy6ZiI3rb1oH0bil0OyijLv4GIx2hOrm57Eh3nzzFpIpWwkE3S09xA2XGQZTKFEyJWODPVVUnJEMHO8cemVHspwhtm0PrxcAaqzIqy4Qk6W8+clOBlNYEjhQcGBuZdPjk5KZcxB1JZJtxXP/hB6/x113XcC0RRzjYojhgPRv8t50GcqLJ7/vY0bnjsdjzpvH5pzNo9XpXJab2FBHpicXq+RACaVoT+fFIivdJx2hFMHCrXMFaqYaTqYVdvFkYcSCYshL6BzT1JiQKj/5ReUx8+enJxeF6AyVprLDGFaaXpiCc4n7RQT9qy/Q2/5fFtC9C5Yq49aa3c4JjgECZCRJEp4jyTimGQ9xFFGMq3Uhxkf8yIZ1oY+O+E18SBqQYSMe4ryu0IvdmUVID5WJnsUHUCVJu0cyRFYMZsQ2LMWpPVQvRl4xKPdiaEJm0fbCLMJuKYrDaRSsQwPN1Al8khGi7SOs5YUTa8njkpwUvP7mI4joN4/PRnKiqKopwu2Ny0b6yKkckaTvRxPZQDnnXhVjz5wn6k4jbuHylh72gZrs/4ria29qTkcnpt06kYtvVlRMRyIMPRUh2VEQ81J0KC1WAjwHkD3djex4SHOAayrZxYWgOY2Ru3LLEPyOQzjg2OxyRpoNEM0fQdmYTGnN5kzFp0yEK7qsvHNzJdx3CpialqE73ZJAbyKZmaxmpsPhlDN/PHZpq9RutNuD7jz2z0ZVuNcNx+3ncQmnRUAJnWfbXFK78hBnKsPMuwNhlEwX2Zsm2EYOU7QCp55qwEFOncBkaTsVrNxkGmW/h+IIKd1gqJY9Mqr6JsWFYkeP/6r/9a/qV/9+/+7u+QzWbnCPsAt956q3p4FUVZ11FkPz4wgX+/6zB+fnQah07QsHbOYAaX7+hBbyYllU3aICh207aJqUpT/LiPGoij5jHLNo581kZXMkSVE9S8SCqsjBJLpePY0V/AUFcauVRCbARsCuM4Y/pgs8m4CEoK3YRhSpQZBSyrxJXQF9F5aKqObb1pdM1EbLUFKMXe3NG6FHtjVUdGEUt6gR+g6Xk4PBVImgQrx5l4AMcPcWi8LlXojB1DXz4J2zJkW3i/A7kUPD8UAdmdaolbCmpuS9tWQdHLGDVWuWmeoJ6kfWMw36r6nqmJZ+1KN4d1sEJekngyH8W6J97eqVrLF63xZIqycVnRZ81f/uVfzlZ4b7rpJrE2tGFld+fOnXK5oijKeoMC7ch0HT94cAz3HJzE3uLx/QzbssBjtg2gL2u3xG7Aw/Q2pitMWnDhhgYmyo4c1t/Sk0LFj8ENQvA/Do9gas+mQhaNhCNxZI/eUsD5Q/lZkUpbAiuSjDJjMkLbC9wWb61qrYFy05XqbzJnIh6zYNsWknNsCO1pbxTO9OcyWiwTN5FPW2g0OHVspvrpBxgspDBeaWK65ovf+JYHhmXKWlcqgXP7s2J3oN+XloCk40oqBHN4uZ1lp7UPmEbRzxSEuCWXT1Ycuc5zA8RtfmdE4v/Np89sOsLcoRhxP8RggXnIdYlZS8QtjSdTlA3OigTvvn375N+nPe1p+MIXvoDu7u7TtV2KoihnlHLDxU8PT+Oug+MnFLs5AFfs6sNV5/TKQfu94zUYUShDGh61OY/MdFMauiyDlgRXcmcnig78MJRBB3QMpBjpFbLa6CEeWAgN+kxbiQc1x5PD7PSdAvzXbuXtzhxyb4s3Ckbx+UaeVFE5gY1V2xib1+ZsLy9reCGmqi4MM0JfNoWkzSqxj3w6Dts2EZRDDBebiMIA5WaAB44WcWCqCi8wUGx62NaXQqUZSNU5ZZkyKY7+V17HsciOH4kdg2kS3kyO2VTNk4gz27QwUq5ha3cWA6wUx4w1883O/gjwWgkTjERmA1smM5NGoSjKhuSkjiZ9+9vfXv0tURRFWSPoa90zVsUPd49j79ETJzP0dQEXDeTQlbHFCztWacCCia50K8/WNlvpBBzXW6y5uL0yKlXdTMrGoYk6zhvMSgbtgckqJpocPRzhgcNlbOtOiYBl0xeFZbXpSqauMdP4xtNcryn/pYWBR914WJ5ik2OF+xekDtAKweJqNOPrTaViGMglJbmAMEIt12djsuIijEJEhicT34KImb9AJMLaFlHNijIrwogo0OMImy4SpgU3aFVzcym7ZY0IQhHsrDR7viuinY/J9Xx0Z9PHzfA9U/YG7jtuH1EPr6JsbJYteN/4xjfiXe96FzKZjJw/Hh/4wAdWY9sURVHOjJWhVMePHhrBTw6PY2rxntx5xEwDTd/AaMnF/skKRqcdmGaEoQI9tAlpVNtUMHD34SnsGSmh1PRE7HWn4zh/oIBU3EDZ8eWywA9gWRzC4GK6RsHKSWchcnFWRTkVzEOTmbZBywvbnYvLUAoi8V9NDyOlJg5O1ZFPxVBp2IibLZtCW8ixwkvvLCu82YQpVoOsRJi1rmNnGcfuJhMmjMhEzfVx4aY8osBAYProSqdwbn9BKtiFVEJuT6nc9F0EQQQ7DmzNJOdVokN6hsMQ23syKNdcNMIAuYSNeCIGI4SIedriKOZpw5gboXaiWLXVtDcoinJ2sOz3/N133w3P8+T8XXfdNW/whHIK0Mj3qlcdO68oyhmFovHOvZP4wk8OYM/08m5DH2shQ09uAN+NUPd91Jq+HMqnmN1cSEuj2nS5gVIzkMonx/QyGWBXEMGNmLJgY1d/Fvuna8jG4+jLJVFIcZ0+XCcUq0CrKSwhMWK0CESUv6WGCFqmHRTrDoo1B5xKHIWhiFV6fymcAU8mH1HYUmwOFxl/5iBhWOjNJRD49NHGZXJbremJV5eT1nKpuDTNmQNZdKUTiNmQZrqhXLI1XriVQybRZbYZQzpvoC+dmLVjtGlXUTnYYcQyMVFxxdowWWnI+GQOomA2L329Pdm4RIbxNqTdYLdYrJqiKB2K3dl6JnYyNoZbbrnldG3P2Qd/OCzIM1YU5cxx/9Ei/uWHDy1b7BImE/RkbZnYNVJuottPIojqSHKAgxPiaKkhIneyHuDoVAVu2IoLs0wTdVZXbQNdOVaCDeykNSIZk4xeimPP81GfmUyWTloSbxYzAceLxIIQhAam6hTDFNmhVHYZG+YHEVIJD1uyabE40IZAmVhqeDg6XcOYiO4QfXlDmttYMWYTGyutFMjMzQ3DAHUvxFAhicGuNHb2mdKExkqrJESEkVReJ2oeJsuOVJE5SW6xwQ3tKiqFK7cviELsm6jLY2Dk2li1iXQyJ8M9utNJqRrHLebitgZaMNWC4losB6e54qsoysbXMyf1yfHbv/3bqFQqj7i8VqvJdYqiKJ0OhdhdByfwni/fjbtH/BXdtlh1ZFLY5kISl20r4JzeNLb2ZJCNmWJVeGi0iofGKoiiQCahFZIJZBMpDGTsVj6uH8no4HP6C7hyR4+I3u58AhOVBvZN1jFaqqPUdHF4vCZ2CIrEbMqSauhQISXJCp5vtKqtoUGTLuIU0ak4+vJxmXA2XmbagiPL1LzWRLUA9BVzkIWBBJvjmq2jdobFejFFJRCySi3+2kjELi0PTJ2gT5m+YxGvARvkYvDDAEG0vKN9FNmDhaREtlWcAD2ZBEqcxhZEUqmuOQHGyw3xUu8fr+HQZFWsFrx/Vnw5KKNd+VUURVkpRrTUFImTmLQ2MTGBoaEh+AyjXMeUy2UUCgWUSiXk8/nTP5nku99tnX/ykztuMomibFixe2gK//dfbsdDpZXfnikNv/q4rfi1x+0UAUov7qGpCu4/WsX+qZqM26XgpKCkPBvMJcXbmk3ZsrxlmdjWnUEqacCKTEzUXLi8TbWJMAxRrnPQMLCpK4lN3Sls7sogETPFSkZbBCesRUEoE9cOT9dlgEJvLoVMwhLPbKnuiBD1Q1+a4LgMq8eu62LXQB6bCknx9AbMxoUBP6INwkfA2DQjRBSaSMYhlodq3UOx4SNDz6/JdAYLXsC8XoplCz1pW+wYS1Veua/Ha00UJSGC3uLWsAreNy0YTOjtpvitORipsAHQQeD56Mul8eitBUmDoNhtD9LIp+w1a3hTFKWz9MxK9FpspSuWQ2VRJBXeZLLVONEePPFf//VfjxDByjJeIG2LyBOeoIJXUU4zFGBfvvsQ3vn5n6F8kuvg8a2pekNG+rLhSrJzTQuO78tgg2rdlYESQ11JDOYzEl3WnY2hWHZxaLouvuGpioPujC2pDpM1elo5jtcXkbt7oiqNcZURX8bw8oN6+2AORhCJBcE2LBkzvCsZRzJmYt9kVcR1IWmBHWGmZYnP1w9NmZC2szcr67atLAbzKRGeFJHZGRGZi9sijGkrGC42MNX0EI/FUW20coB7MwlpjCukjjWtJTJxsRi0kx4W289tGwKb7PKJlqevLVZbQyqi2THIXE/T8VBrMAXCFmFPgd+2McwdpKEoSgcSdLaeWZHg7erqkg8gnh71qEc94npe/s53vnM1t09RFGXVoLD64p0H8dYv/BynehyqVOOUtJagq3g+jhQbklNbbTrIJhMY7EpIKkG/VF7pcbVwNFlHXarBdXRl4ig3HNRdH6WmD5PH2iwDFaYXRBaMMMRUvYlC2kbdA5xGgGbAoQ0RQjtE3QmQyFiSnLDJyyARN5FNWtL8xTHFThAga8VmBSbtCawyJ+Ox2YawtohsR3IxsME0TAzlWyK8P5dEPMnBFSH6c7ZEjtEiwSEYKU6C80M4bgA3iOY1l82d7NZuPGNT22JfPjGrJYzp3+3PpaUZj7FstGa0Ex/agzbUw6soyhkRvGxcY3X36U9/Ov7t3/4NPT098yat7dixA5s3bz7pjVEURTmdHC3W8A+3nrrYJV7oIG61RN503cHPDk7jJ4eLEsW1q9/CBUMD2N6fQU8yIYfxaXswTUMmmY0WHVQock1m1kaoNFypwlKMbu1OwWkGOFCsy2F/ZuRSWNPiUG96oNmBgyGYq2s5QNMJ0ZWJoVjzYZuGVE270q18WVabKVwpPmOGgUKmNXZ4KRHJ23OKGscP92biGMol5DqmT/A6nm/fhv9S0LatBnPHBB/vuoW0m9u43b3ZhAh3ji7uzyZkf8xdRlEU5WRZ0WfIU5/61NmJa9u2bZMZ5IqiKOuFnxwo4eGJ1VkXK6icMMahFQfGa9gzXpXhD8mEBd830JdN4pze3Gz0WTxmYmtXCnHLhM9c3CCAGUXS4MZGsAdHKrhyVzd6C0lkOBBhqoZoJgas1gyAQoRUkgLbgMvEBtOEBQsNpjpUPbnvvBsTK8SW7rSIxCKnq9VcKVTYCXve+Ny5KQrcvrbwLczEiWXEcxyX7U8u8qXRbLhid6i6DaRtu5XnO8NKbQjcBlaL+ZXCdAZOQGuLXUVRlNXgpD5RWMkl9XodBw8elEaIuVx22WWrsnGKoiinCsXUVK2JfeNV/M99h+Gs0i4dmXTw86NFqUr6IcQDO930EDMi5NMWEnFD7pve2WKjNfrXsg0RpExTYJzXkXJDKrjphC1JBel4HFEA9BcSuDrWh91jZWzuTiFhMdLMQIa+3MhAIQWUmz4mq1VU6q7YJLj+GG0STQ8DYSQjhDk1jR5eNoLZVoB82p4nPudaD5iI4DANwaH4jWDmkkjOWBIWQpE/XmOcGXOAm8gnk/C6EjJ443gV5KVoV4Szybh4lFlRjgUtb2+7uqwCWFGUMy54x8fHceONN+KrX/3qotezgU1RFGWtoWA6PF3DF350CP95zz7sOdkutUUoNoD7Dpbw2O29GMzHsbM/IwkL8biBCzYVEDdN8eZWOXAiBExWZp0IThhK5u5IqYGupIV8glm+dfRkk1KJ5XK9aUZ2+ZLmQBEdrzbQW0jgnL4sHC8U0cyGOebz7h9zpELLoRQmGrhwS14EIoVma9qaL5VlJjgsHA4x13owWW2iWPMkLzdmWqg7PvJJe9EvCYpQXs80ip8fraI/46LUSCEdZz5xclk2BIrmuVYJnih2GxKh5qHmeJIhzMfL3GM+hhOJ3tM9oU1RlLNM8L7+9a9HsVjE7bffjuuuuw5f/OIXMTo6ine/+914//vfv/pbqSiKchJQCD40XMHXfrq6YpeUQ+DAVE08u48aKkiuLCupPMzPhIZE3EbD8yRurOJwChpVr4GpclNyc9mMNpCzZXhEbz4uvlmK0qRlws4l4AQhDIPNYinJqA38SB4Pq8G2ARQt4KGRCg5M1iU1IWYbrWEYmWN2gPa0s6UE4ELrgW1FMEJL1tdrxcWmwPtsUHwyszeCJDYwQ5jhDIen6hJpZsYM1F1PMn6XA8XucLkpgpnNdJvyyVbTGz3I8JBLxjFSqmOy7KIrG8dU1RFP8fEE72KNcip6FUU5JcH7P//zP/jyl7+Mq666Sny8tDg861nPkgy097znPbj++utPZrVnJ7EY8IpXHDuvKMqqIAKo4WH3cBEHiqu/U5k5EFmBDGFgzBcbxWquh2LTheMEODJVR2/WlsvzcQu7xxo4OF1FvRFg+0AG23rTGMwnEAbAwck6Spx+5gfYP1kT0Uu/LaezUeyxUptN2hIflp4Rcj0ifjmS10ax4SIjsWgRGm6ratuumh7vU2Wu9YDilj5jCm/LssXLS1/tVKWBB0crEldGgXz+YBaP2daD/nwCW3vTsBkn5odi7WBW73JgZZdil/m7MhwjjJCMm0jxeWNUmcupa6aIeIpv8SufwAe8kkY5RVHOPj1zUlvEiWrtvN3u7m6xODCm7NGPfjTuuuuu1d7GjQ27NLZsWeutUJQNBYVPsebiyDSng4U4HWmQm7LAjp4uTNdcfP2nRyR9gcKPh/rZxBaZEbJxS6aW2XZMrufh+YF8BgfGarhgMI8M8285UtjxWwMlYhb2jFVERO7qy6E3npQK7UBXEgmTvuBWTBdh5FlfNo64DfSk4xILSQsC17MSsTdXFPM819FOYagyH9ijLaQOl2LSjuHIdBPbez305xI4bzCPnmxCBkiwWt1ucjsRtDGwskuxy3/590IBzn8peht+IPuQQv94aF6voqwxZmfrmZMSvBdccAEefPBB7Ny5E495zGPw0Y9+VM7fdNNN2LRp0+pvpaIoyjLh4fK7Dk3itvsncbhUQc110dsF1Fe5yjvYlcJQJoEv3nUIDx4tot500VNIYEt3FuMNB1nbxkS5gemaBztuwAqATDoO2zbQmy2IpYGVYYq6gRxzbz24biAV24FcAjXXx7aelAyKYIVzYdoBD++f058VgXuk2JQ58UPdKUk5ONnhDPMqwmKp4AjjUCap0T6BAMjFTUmn4NS4XDw2K5BXYh/gttPGsFhD2txt6JsTg3ai9Wter6Ioqy54X/e618loYfL2t78dz33uc/HP//zPksX7D//wDyezyrMXNvjddlvr/OMe13GTSRRlvVV27z1axN9/+2Hcua+E4kz/bPY03JcXeJisO/jJwQmMV0MEPlCsOWBgbpxNYKU6mkEgh9iZ4mDGTU7nQVcygfP7MzJ5jDYCsSukQlwwkBU/MAUmx7fTJ7u1OynJBUuJvq5MEpduieHcgUASGbiu9hCJU0UiypIsH2eQScTQn6VlozVkgraHyVpTxiOf7JhfitzkMrZhJV9SmterKGtI0Nl65qQE72/8xm/Mnr/yyitx4MABPPDAA9i+fTv6+vpWc/vOjhfIN77ROn/11R33AlGU9QQ9sD/ZN4m79pZQ5KSGGaqn4b7Giz6C7RFsy4JphPAApLJALpXAYCGF7lQSh6erqLi+CN1cwsTFQ124eFsXujI2GkEAwzdlYlk6npLxu6z4clhEZBjzKp+xEwnH05RZy/VSRHalOXrYxkNjVRyZrOGesoPtPSn0peMnLXgVRdlgBJ2tZ5b9KfnGN75x2Sv9wAc+sOINee9734u3vvWtUj3+4Ac/KJc1m0286U1vwmc+8xk4joPnPOc5+MhHPoLBwcEl11OtVvGHf/iH+NKXvoTJyUns2rULv/d7v4ff+Z3fWfE2KYqyfqg2XNy1fwr/9ZPdmJ4jdk8XjaAVwXjBUB5RWIYXeTh/qBuDhQzO6UkhmbRx4da82AJsExIJlk/HZFgEx/EGHPjg+UjHE/NEY6cJSKkWMw83itB0AolVGyqkEBlsFDs564SiKErHCt677757Wcvxw32l3HHHHeIDXjiw4g1veAP+8z//E5/73OdQKBTwmte8Bi984Qvx/e9//7jCnCkStFjQV/zf//3feNWrXiUjj3/pl35pxdumKMr68O1+/6FxfOy79+GukTNzn5EH1D0Pv/jYbfjFK4FK1YMVMyQ7d6CQRL0Z4JyBrFgT6MtlxXay3sDDR6sYrToYK9exaygrQyg6nbalYnNvGiXHRRCG2JROIsFsMkVRlI0keL/97W+flg1gRfalL30pPv7xj0uOb5tSqYS///u/x6c//Wk8/elPl8tuvvlmXHTRRbjtttvwOPpDFuEHP/gBfuu3fkvygckrX/lKEdM/+tGPVPAqygbl4bEKPvWDh3Hn4flTH08nTJw9UnFlLPATz+8X/2zDC2RgAgWil6bdwZTLU7Yl/uLRaQcPjVdRa/oiFnOpOHb2LC+7di2h2E3YMfSkgcu3dyNpWSiklp/KoCiKstas+SiaV7/61ZLb+8xnPnPe5XfeeSc8z5t3+YUXXig+4R/+8IdLru8JT3gC/v3f/x1HjhyRqUUU6g899BCe/exnL3kb2iXK5fK8k6Io64PD0xXcfMsDuPVA7YzebzEC7tlbwadu34tP/3AfJmoNyZXleF2etnalZRhFewCCZM9KkxpQargouQGKdVfsDZ1OOwGBj29HTxZbejKnXezyBwI92TL2WFEU5RRZ02RgenOZ20tLw0JGRkYk9aGrq2ve5fTv8rql+Ju/+Rup6m7duhWxWEwGY7B6/JSnPGXJ23BYxjvf+c5TfDSKopxpG8NDo2V89JYH8J8/n16Tnd/kUaV9VewdabXF/frjd0lywmIfrLQ09KZtHLVbUV7bejIylIKNauuBM5mAoFPTFEXZMIL30KFD0qD2jW98A8nkicJplg8FLy0PrPJyAtytt94qVWR6eBdWkduwWW5uUx4rvNu2bVu1bVIUZfXF7jfuH8Y//2APbj/Dld3FGGkAPx8pouIE6MosnXiwvTeLtPzrSEZ7IR0Xu8N6bhSseQFsDr1Ix1dtlK9OTVMUZcMIXloWxsbGcMUVV8xexo5nCtQPfehD+PrXvw7XdVEsFudVeUdHRzE0NLToOhuNBt72trfhi1/84ux4YzbC3XPPPfiLv/iLJQVvIpGQ05rA8Xsve9mx84qinFBk3b5vHB/9n/vws1H/pPbWn99wCc4dzOB7PxvFvUen8OCRCg47p7bjYxEHQxzfj0vRu7U3K4McFhu6sN6eh4fGKpioOkjETJzbl8VQV3pVRK9OTVOUdUiss/XMmm3RM57xDNx7773zLrvxxhvFp/uWt7xFKqy2beNb3/oWXvSiF8n1nO528OBBPP7xj190nfT88kQbw1wY4h6GHeoD47bu3LnWW6Eo64JirYk7D0zjs3ccOCmxawN49w2X4CXXtt5zl2/rxX3DU/jAV+/D4T2Vk96uwQRw7Xn9KKQTqzZ0odNxggilhodcMo5q05MRxCsZaXw8dGqaoqxDzM7WM2smeHO5HC699NJ5l2UyGfT29s5e/vKXv1ysBj09Pcjn83jta18rYnduQgMFMj24N9xwgyzz1Kc+FW9+85uRSqXE0vCd73wH//iP/3hS2cCKonSWjeHH+6bxzz/cjZ8eXHlj6XndwBue+xhc/5its+ubrDnYPVyD43NsxMnRDeBZlwzhyp09HZehezphNZulhSNTVSQTMcQtY3akMT24xxsJfKLriU5NUxRlNem8mvMc/vIv/1Kqtazwzh08MRdWfRlhNrcRjp5cRp1NTU2J6P3TP/3Tzh08wckkd97ZOn/llR03mURROgEKpD1jFXzlrkO4Z1953hS1E8Ga63UX9uCVTzsfV+7omxW7D4yU8eO9E7htzxjuPcD2s+VRAHDxzpz4Vhk7dvHmAp7zmM04dyC/ah7W9UAqYWNHbwbbejMI/BDdmdYI5Kb4esPZUcftlIo22pCmKBuUoLP1TEcJ3ltuuWXe32xm+/CHPyynpWD02Fzo72Ve77p6gfzXf7XOX355x71AFKUTYDzVw6MVHJouo7pCd9KvXDWEG596Hs7rp1RtMV5r4PsPjuC7D4/iZwfryx49zA/M51w5iGt39qE7ayOfjGNrTwpDheyyt2c51c31ALe/kEm0YsMMwAsiNGoOyg0PjhcinYzJgIp03Jr3RbNUQ9py9svp3Hf8EbTefdWKsqYEna1n9F2tKEpHQ5FzeLqGew5M4uiUg5U4d6/enMBLn3jOPLFLH/C9B4r40f5JPDS8fLFLrthi44bLt8vEse5kHOkF1cvlPJaK48tIYU6lLCTtjhZXxxOYc322XK7uBrBjFppuE34Y4si0i/5MAn2Z6IQNacup+p7OyjDF7nC5CccLkLAtbMonO/p5URRl5eg7WlGUjoXi5vsPj+DTt+3DHQ8WMRWtrJHs159wAc7pzc0Tu3fsn8J390zg6HQdUyu07l65azMu3lJAJmGvWGxRVLHJa7rqwItCNNwQQ/kkNnevTrLBarMcgdn22VK0ukEkQt6OGajUIqRtC5FhiCBeSii3xS8r+LytaRgoNxzxAy+8r7mV4WrTRcw0kJpZ36kiQ0G8QAZrTNcc+Xu9NxUqijIfFbyKonQcFIfTdQd3HZzCB77yU+xZYY9arwn83nMuxvMu2zRbqeM6945XcO+hKUwV6yKwVsKVm2J4zmM2LTuJYS6878PFOsZKDeyfqqJYcZFLJTFRaaDp+8gmYrBMC5m41THjeleahStNa4ghyvB2QCoZA8JoWQ1pURih6viYqDQRhgZcL8RAPjnvh0VbHFPsNrwQETz4YbQqlV7aGFjZpdjlv/xbUZSNhQpeRVE6Lt/150eL+N7DE/iPu/Zh/wrF7sW9FLuX4ZmXbJkVQhSc9w2X8J0HxnH/0SIeGClhbJkpZNtSwA1Xbcdzr9iKizcxk2FlUDTW3ACVhg+mIw5POhipNBAz6rDMGH62fxqOwYpoDOcP5XDNOT3oy6bX3Oe73CzcdiW45rgoNwIwqCJumyIa0yl7WckVnDZHi0cAQ8YuT9ddNL0Qm7pSMo1OBHK7ymwaInYZh7YcIb4cuwZ/FNHG0PCCde+tVhRlcVTwKorSMVCE7J+u4as/OYJbHjq6IrHLtrEnX9yNlz/5Ubh8e8+saOE6d09U8Z93HcKPD01guuLgcAVYrjvi6vP78X+edoFMEpu7nTwMTyjoFqYQtK+jeGr4ISpNF1PVpviQHxqpoOh6cJsB7DikqjhVDGHHgO39CRTrO3HtOf3IJm0Rjt2p1ZtgdjqycHl91XFRqvs4NF1DfzYF7qp8Molc8liF9nh+4NZlBioUui5FswHDZNZvME/Q8na0MbCyeyIhfjzaIr0pNgoTheRMldgP4XA7HX9e5XijNBoqytmMCl5FUTqGmuPhu/eN4DsUu8Xl324oAfza43bgmZduxgWbu+aJkslaA7feN4zb901g/5izoiY1IQwx2WjONqixWjxabWKi1AQMA4O5hEwYoygq1l1MNz14vg8e4DeiEAEi+H6EB0cr+PlICYcnK5gshaC1tRkA9fb9BMAox70ZhzBZ8fDYnT3ozsbEC7tWIms5Wbi0IzScEKPFOnwvFKtIOp5APNaqyi7HD8zzbAIcKqRk/3LZKAQSlvUIQbsaQykkPs3zwYCJUpMj9iKxlSyVHnG6muUURTlzqOBdazh+79d//dh5RTmLue9oGV++ey/2rUDskvO3pPH8K7ZhW3dmnshipXXvSBU/O1JEseFg+Wm7xxh3HByaaCCbiCMXj2G00sBPDkzhaNFBJhlDpSeDqutjZLqOw9N11FyKJgupRAzTJQceQhyaLOPARAP7RqsoO3NE7gJYdb7vUB2N5hGMVhuS8Rs3TWwqpCT3thMrjLQj0L/blUmgGTQQRhHyCWuelWE5fmD+oNjanUbN9bApglgZlmoOXCjEj1eBXew6nmdll2KXlfR2vGXbI0x7BYX8crd9NdFqsrJuiXW2num8LTobR/E96lFrvRWKsqbwS77ccPHNnxzCA5Mrv/3jd24WsdtuUGtX5SoNFw9PVFFsepIVu/JhxEA2nkA6HpNGqoYRYGS6iQMTNeydrKE7mxS/6b37A/x8rIy6EyJpQRrQaEegePPCEAdHyxgtLy1058IK9OFpBzGrBM8LkTAtHMk1sKsvg55cSiqMrILSF0xNWUgl1lQEUzxS3CfdAI8aLMA0I3Rn52/T8fzATM4YrzqS0NCbYZU3vSJh336uaaugk4T2hPyMDWSp6ixPXI4/MSh2E3ZMBLplhHB9U4Zm0IoSs8Jle5lXA60mK+sas7P1jApeRVHWFIq3g9M13HtwGrftHl7RbSk9fumibvzS1Zvn5abSGlGseai7Lo5M1DFdqaO08mnEEk21tZBC3G41YlHsRAZgWpY0TU1Xm9g/Xkap3MDRkoNGAMRNHoqn6AXcCDBCYKQujoVlU/aBw1N1xJMGLg26UZmsoi+XhGVysIOD4ak6yi7FMHDOphw25U4cbUZhOVFz0XACpBOmVFBXQyy3xKMtz0Z7utrCRrWlbAgTlTp+tG8S+8bqEmd2yZY8HrO1B4klkioWq362PcTjZUd+jHSlbZwzmEVfNnnc6mz79cJGtWiO75oBDZnEsYY4PpZTtVCciPbj4r9nspqsKGcT+l7qhMkk997bOv/oR3fcZBJFOd1i96GxCr7/0Bh+sHsED02vLGf3xdfuxK9cuw1bu1tZuxQL9OzetncKw5M1yYYdKdfQ9AMsM5RhHrv6DGzpyojoYfMY6eeEtXQMY2VIk9W+0SImeJ6VzJYV95Rh8FkiDphRKF7hnmwCw6Uaqo0EIiMSMbylKwmHHuBGiCC7uDBqC6lD01XctXcKDxwpY6LhIBOzcNHWLlx7Xh/O7cudsoijeOQ6jicK2zaEttXE8wIcnm7gwHgdVow/EExM1Tw4QSQNiAvF7WLVT56nYGVlfbjYQMw2pdGt0vQkU3dhdZb3WXd8uZwe44rrY6rSRNUJkUuY0phoLVLNXY6X+WStCpLP3PSk0sz75j2eiWqyopxtekYFbye8QL70pdb5iy/uuBeIopwuWuLUwYGJKh4aKeHgZA3LnQMxmAR+/ZodeOmTd6Evl55dH9fzjXuHccuDIyKcfM+RhrHlRpAtxLZieGisjFjMRCZhIZ9IyGG7nnQC+UQDd1ZqqDZbYherJHYp3fMZSCZvfzaD/q4kbKn+GZhsOMjH4zLAglXsvnwCViyzqDDi/hiu1HFovI67D0zh4fEyJisOpiouYjELDcdHKmaiLxNHb5bZB6cu5E4UQTY3HWGy0sTRUlUsECPTLS/tzr4ULCOSaLrDpTo8L0JXzkZ/OjkzHMJHdiaOjI9/qs4xxgEarodswpLYX54oZtvCsl2dpdgd4eOvOiKu+7PxVrXetGAYgTyvbGLLJVtNgnOF9mJCdSVe26WsCvy71PQxXXPl8QPhbLJFJ/q1FWU96xkVvIqirAnSKe8HmKr6+NmhcRworeDGPi0GMRwtNmFbljQ37ZuoiNj93p5R7B1vwLIBp9Hy7bIPf6UMxIBsKobudFKmsv38SAVxu4rJsouHhsvYPV7CeMlD1cWqwcpuJgls7cnggk1d2NGXwQUDedS9QATdSKmJh0eLIswG8wn0ZVNIMc9sDu0K6lStibv3T+OB0SoeODotft/hyarsD8sD6jkbUzXGiXnSwDXXjrBS/+xyEwz4nLN5sFz1sGesiphtYLCbvmQbuXQcuVQCw+UaRkoe9o9VkEzExGt77mBBbBgt14Ernls2x7Wno4VhhM09cen6o/WkNxWXfUBfOBvQUjNT31jdpbCk4HZpHRA/tIuIyjcM5bZzH//xhOpKHzeXtS0TNcefnSTHy7nfuU1VqUrHV7T/FUVZPip4FUVZE1hxo6j5+P/ch8PL6eaaw6gP/Pm39mDwe3vwhAu68dSLtkiD1/7pKhocgOAD0cl0qM2Z1LZ1IA4YNvaMFbGtO4vdoyUYkQHLNDBSqmGi6sJzVqeq24amib58DBduKuDiLTns6MmiJxdHL6ubAZCOuRKBloybqNQ9JCxDKp31eAyJuDU7sWyy6kgm7oNHyhiu1qWxznWaInqjKESlAeyfKqO/kMa9h0rozsZFPNLXO9STXJYneKUJBjx0z4rz/9w3igeHy+K73dVfQE/anhWM9F3vHWtguNiE7wN9MNBoBsikGji3n9aLUAQhBaPEls1MR6Nw7c/EYdvH9sHRqTpGq46I3YFcAoVMDMmYiWLDkwovY8j4eLtSNoKAdoJWhXru417q8a00uUEq8AY9y60ou4TbEtYy9MKOiQCncJ/NA1YUZdVRwasoyhmDIuFosYYfPDyBb/78CL7/cAmNU1jfqAN88afTuOfANB533iaYRojhcX/ZQyUWgweWk2k2LqXQm43jUUN5aQ4rNloWAYQce+yhWm+iEbLeuHrQ0pGO2+jJpLGpkMGuwSy60kkRca4fIp00MV12UHYDhHCwb6KOTLkh9gDejtXuuuei0ghFXBUdF7WGCwsmujMplB0fnuMBVijZufcNT8qEtEs2d4Hu0Wo+CS8IkY5ZYh040WH15SYYtEYrN/CDB8dlqEixVofjA+W6h3P6cjBNUyqx/JWSTyflyOh4rQ43CLClKyVCtVR30ZVpCfNy00XM5FCOGKxsQqa6tZvQWNllOgYf63i5gVwqJkcSzo3lkMvYIu6Z79vOVcYyhOpklT8WzNmosrmPW9I/gmNpDovBy5mn7CY4PtqWfTy3IS4db4nflYpdjTBTlOWjgldRlDMCRc+e0TL+9tsP4Cv3raA7bRnsKwHJQ6MS4VWPTl10TlcBt8vDo7cMYktvEvcfreLAdA35pIUgjKMvDbhhBtPVKmj/XGGBeklCfijHLYxXagiQl+zfti82GW9l1falE5iqunBcT5qudk848I5WkEvbCN1A4rTo8fWDCCWHcjwSO0CEkMVFhJEB2wCoeyeKDuoOMFn3sCWfwjWZBEqOh+maJ8ud6HD9codAVBxPbCHjNQfT9QYcn3YWNmcFqHm+CEcmSHgUuN1pXDzUjV2pLJKWid5MEmOVOpJ2VgZ5jFc9jFccycvdNZDD+QM5yQJu2wtEpEaQZrTJiiv3u7UnjQs35xAzTOSXOe6Yr1c2xNWaTPtgeoID1w/Qn0mIuGaVmVaKatNH3fFEyLbHIC8G7zM9I3ZXoyFOI8wUZWWo4FUU5bTTbs65bc8UvrnKYrfNA2MhEghXNFwiD+CK87MynOLgnMY2uiF4uP38oQyKjQBT5Tqma00krJTEg9m5uDSyjU5XMXIScWfHqy67biQpA3Fr/vCGNhRbmQQrvAaGiw6OTNfgOD7SdRtGaOBwuYrQi9AMAonm2lzIo+i6SMYMZJMu0ikP0xUXvusikUigN52UBjmeEgkLhYQt0VziN3U9UCrzPk+UvnDcHzpjVdx7uIiDk2UkTUMmzLE6y0ZAenEPTVUwUeGEOlppQ2ztzmBXfxa1uo+HxkuoNzyMlxxs7c5iquFg31hVmtPGq03Z1oF8SiqtrKJyO5mb3JOPy0CQmJmEaRqYKHkY7J5fhT5ecsJwuSm+2rpLMRtDxQlQbNTRdEN0p+2WRaHsYKrZRC4eRzPeGjhyqj8OlsuZHoihKOsdfX8oinLa4ZexG/ioNpsnNe1sObCwu5J1dzPD96ohiTQbntwHE75UWMmWLuCpFwxKSsORqYpk3vbnkzAMExduLsB1fYwXHclZP8WC8jwYlkCNuymflKa0doMUD9O3KnqeVB2bTgjbBGIzE8HoQa00PLiBh8lKA6MlTwZguG6AVMJCRI9ALImebBJXb++XGCzaAkYrTTheiIFcElsHsjLed2Dmfo8U6yjXXVl3fz6BgUL6pMbqDpfruGf/BEaKDhpuiG19BWyNQthxCwPpFGq+h2LZw+hMmbx51EFPuij+5cgEDk5UUXMCGfTRn6siHee2NXDOQBZjZU+a3AYLKbF1lGiNkEi3lke3kE7AtoB600fD91BvWPCTrQrr8SqkrUSIAPmkLQkKrt/a7xxuwuei4ZsigqcaTIngi4+WjhPvi5VWc9tVZhHxC/b9mRyIoSgbARW8aw3H7734xcfOK8oGRLyPkYHeXBoDNjC23PyxJWCIVncCoIWyGqxM6LYruy9+/BZccW6fJB/0ZFPY5FYwWQW29wAvvvJcPGpTBgcmG1JFdH0fBSuOzYUk4qYh9oYHJ6cxWTy5BIjFoJSJmZycFsfmnqyIrgMTFXgUs46PYtURqwIjt0bLTe5UEURdyQRySU6Ci1CsshkwhAQ3GEAgDVwuOGguqpfRm0kx3BfnDWZl353vt6bRbe5KY1t/BrZhIh6z5LD72HQdB6YamKo7OHcwg5jJyml2RV8aFJNHJht4aLwq0+lGizWJGdvVm8M5vTnEbQthGYgnTBj1UBoAqXsPjFdw39Ep9GYy4l1mAkcU+ChVG0glbanu/vxwCecN5KTy+3C8wplp4j2ueSF29Wakuk2bATN6q3EP23uz8qOA+zV5ggopPcE8jVbY9GYiS7uIz0SFSBIVbMOQhAuDxpNkDH4YyXS35Vgllguf2wNsvCs1pMluR29KptC1Re9qV4wVZaPrmc7borMNloguuWStt0JRThsyHMAP4UchtvdkcOnOLP7nYQ7QPXm2dJnY0Z/Fef0F3HPgMG4/svw6K2XBy5+6C4+/cAB+SF+riaddPISDEznkUjaeesEAHjWYRyMIkEq6UuWrx22p/yaTJn5ycArf/Nkh7F5JjNoyrAz8ME7YkJHBhyeqqHg+vIaPwIQcQmcUGdMXupJxyZ/lMAqKwXjcQqUZoCuThBcxxzUOP2yK5SGViqFY8VFquOjNJxAgQhCZ0pDGPFo2uQ11p5BN2CjXfZhGJBFovI/pZktkp5IxGQ6xszu74ioiY8Amqg0cmarjgcM11MQfzYa/Kamg7ugtoOp46M+nMT5dBd0hlIxuFOHwZB05syVGeWJFe7jkoCuIsKU3LY+JOb7NmWo7q7y9hYSI4cmai02FpIhe7qOxqiNit914NrfJbLEKKS0cXRkbTT+UqDTaO8IogO+bSNh8rZlwGx5s05KItE0ZW6rkqyk6WdkdLTZaucW+D/bkMclh7n2sxkAMRTlb9Iy+VxRFOS3MHZdaqjviG903UUIYWqc8mMG2DVw82CUVzJWIXVaGX/mUnfiVx2+DaVgiyJpOFTv6M7hoqIDtAylsKXDOFxDWXcSMlifTCwMRgHfuncQDw0UcOMlBFks9nu5Ma0xybzojntSxWgPjdQflmo+a72Mwk8COvpw83v1TVTS9QBrQKNZynBpmWZis1lDnbGPmycYiBCHzZ3mI30TDMzAyXUWah/J9+lPrYstIxm0RdFyKubRMTWj6TfTnmGkbyfQvHtLPp3g4feXPmzz/HDlMoT1zGUVvxoWMOKbA7kkn4Xo+JrqriJcB34CkMrDeO1b3ZdZv3GoNlEjEgL5CAp4bychmZjh7AZvgfKSSFuyaiQs2F5BNxsRPS+HKZj9WxSkgKbIdvi4dX6qjS1VI+ZplZV0SH4q+rMtxfXhRq/qbz9jyQygTj8E0DPRmW41s7duuRtVVBLhpSJYwX+GO0xo7rCjKyaGCd60JQ+D++1vnL7qo9QtJUdY5c/2RFAp375vCNx84iiPTTUwUTz7ToMsEdg7a6EolMFZr4pZ7xlZ0+5dcM4Qbn3quVDi5fWTHQBa+S2HGaVzAdMNFLh6DbRnoTsdQrbu46+CEDJgoNU4cQ0ZZuDkNmBbghBSvrfSFxT58N2eAax/Vj/5MCkem6xI3RsFbbzJhwUGt7qC/KyUVcjcMRMgVG02UGqycTsFjtJVpIGGZmG74MjiBlU8/AroyFiZox+AkMieSy6puJMIv50fIJBnxFcL3QwRGhIdGKmhSrHkRzhlIIS7iOIAXssIcF8vAockakgnGgbUE3onEHTNwh3IJbMqncDRTw5Faa7gGtWHCiqE7m4QBA03Xw5U7B3FoqoZGwCaxOFKxGCabjlgOYlyWObpMqcgkYEYW/MiWLGSDvl0zhnTCkgpvMm49wl4glVD6cv1A1leRWLPWQIrFbAh8TNSWtJcEUSg/jOp+q5lumK/fwJDXC38U0O7QXkdrTDBFuC/eZ/puOVSjLYZXAm+7tZCE5wfSjFc4TgKEonQEYWfrGRW8aw3T1T/3udb5t70NiDN6XlHWFwuFz9zJUg8X65K9eteBaZS8U/vQKYbAT4Y9SlMAK7NFPPGcDF5w9U459E/a+adp18JY0ITnBqjWfRwp1ZGkWjWAYU5YG57GkdLxhW6eVckUsLU7iXMGCsgnGD8FqcQenq6h5tQRRibs0IPDTN0QSKdSuGggi6ddtBW5lIl9k3UcnqhJRuxUtYmoGmC6ztpohIGuFLZ1ZbBnvIj7j5QwXnHRdIFsmskENrJJE24QocxECSeC67CC6slwBj+EpCLEWDmuNHBwooxtPWlkUjbruujJJFFvBiKI84k4jtbrGJ5sytQvO24jazHyK8LD4xU0nVZV+MLBnKyDFc/jTRuj0LtwUx6/cPlWmVj3s6NTyNkte0hfgRYAYGdvViq9PAJAkRiLGygkUvBCH6PlujS65TNJ9OUsbO/twmAuISKeTXWMNevPJHHOYB7nDRawpZBCdzYhr0O+BkW1Sixaa5xxkwI/bMpzEwQO6jELheQjBSlvzx8PrKBzCh3zfzmi+vBUTX50DOTjsGdEbntYRXtU9li5KfadybKDZMLG5nwS23szKxa9XOfm7rQMFKH1hn7k1fQIK8rZpmdU8CqKckos7HZPxVqCNwhCjJeb+OFD4/jRnmkUZ5wHp9ivdlKpCL951SBe/Phz8OgtPbOVODYvBUEgjWCHijXcf7CE/RM1TNQdhH6AQjaGKDSwf6y6pNjlMLZtg3Gk4wn0JRPSGHXteQNI2AZ+cqQkwnVzLg436MJkvSlNT7Qu0FLAanIyZsMJAgSNEAnDwDkDObEWFJuOVGLTMVMOpw9m4iLAJiseJqtMDQBqFLEOYEUenCbFr4FSPUI0I26nnJY3mFYCbn8qYpOfDyeI5LFHfojebFKql07oI+RwiApHNZtIJiwZ0MBoMzZp0f86WWpVWz3fl2iwgSAlj+dEsVh9uTSecG4M5w7kcO+hbqkkH5qsylAJNrLxR8eFQwUUu1zkp+KyzkqjiWSM09NSKMccaRZk4gKtFtt6ctLUxvWyCrqpK4HHn98n1de2IJz7emReLs/T28w9QfsHIg8wTLFr8JeNVIAXeGO7U3GprBL5IWcY4q9mfBuPECwU96we8375E+XwRB18ptNJYKLqSMLHiQTvYtVy3mZw5gekNqYpyqmhgldRlFNibrc7hwHUW7MOZKAAK4r3HJ6cFbtnkgt6gCedtxW/dPU2XDCYnxUcE5U6do/VJOuWh7ana74I032TVewdq+DotIua3xKKLYn0SCiDLho08ZyLdmLnYA5RRJ9nHD3pBLb0pEQQVqoNPHR4GqOVOiZrPhocQ8y0hPaACRsYrdbAevX2nrQMk2DuK6O4jkzVUPdpswBcL8Te8RoeHK/hwPgU6k2gGbY8vxyfzGlv1GWOG0nTG4ss7sz1kvww0xTH89R8rPpymEIvhbgXSkXUbbS8trQFUISzmY0NW705Vn9bh+eZRDBeaUrcV47VRsuAFxknjMUSW0sQyNHOmGUgCH0YMQN1JxBfMG0J5/QD/XYSjh/KeGE/ismQCdoncumcVIA5tGF7X1bsAjLdLAywtS87MyI4gQwf/IzwnJu+QIHbbk7jGF/+IGPFdKLigLqSo4mZUUxBPZe5IpjrZHMajw4cT9xTFLMBkNvDZryIQz5iJ44MO15EmjamKcrqoIJXUZRTYm63u8RgNVsC6OB4VZq87t2zih1ey+TZFxXwO9ddLMML5oqHasPFfUcquH3fJIaLVeweLqLmhlJtZGW0VAfmbu1Sld1tBeCSbf0YKCSkeckwbQwyO7eQwtHpGj57xwH890+PYKR+nIo0/cJFAPcP494UUA+AarPlb2U8GSvAbNRiUgKroNRMrP5S3Bp8OH4r1YHuC6rZisMpbQAdG77X8spSVLPombEhaQ9+AOyfqiFut/yr7Pqn7YLrZ+Uyn0mh6QZSIXbcEGXHkTi5yDAkAmy64WBHdxbn9GeRTcVP6OHl9YeLtdbr4FAJB6c4Uph5wRwIYYl3eChI49B0HXHTxFSNOcJNWAbEMlH1AvSkbPTnEoBhoS8XRxSFUvl9YLQs/uVtXSlkZiqxi439JRS5xpzxvdyusQg4MlmXyC8O12B1eKkq7HIyb3n7Qqb1I+L8TZY0yFHwUpCzEn08dIiEopx+VPAqinJqHyJz8kCbroGGF4q38mipid3jFaxieteyoOx63sXbcW5/BpkFvlIezh8u1XFksoYfHRzHaLlVbV1JAbo/Djx6Zw8u2VRAIZMUz2kYRJIEQJ/od+4fwVd+fASTrZ64E7KfsQU8LQJlVYbxXlYAm7nDLmBEgByVj7fErhtQkFHocmkDZixCJkU/b2tfUAoywYBjcZnHS7G7f6yBfLKGJ1+YlDupuJ6IPdpQKCA5mWys0sRouYG+XEIO77Mqel5fblbsLqf6yMooc3h3j1axe6KC4WJDxhqnUzFsyiUQNygiHTx8NGjZFfqSyCYsmW7GamxvLoFtPSmxENDbTHuHK1aUEIWcDRutARNzhWr79SgDItwAdQr4GauNE4WYqnHYRiQT3fLpODJxc9bm0XJ3P5LlZN62bRBBsrUMWa4VQYdIKMrpRwWvoiin/kEyI3z4xc04p1HPRxj4IsZkXO4Z3MeUYvTfLjxETRqeK0H+D4xOY6Lcsi0sjAirzvlg7E8Ambwpo3r7cjH0Z7N43PkDuGZXH0xWJOsufC+S6WS5pIXvPzyBz92+d9li90RE7e0JgJwLJEzm9LLhakb0BlKAlepvImlI1dSLAiTiEbIhBX6rqluscEHGuQHVuoOhrgy6MxYmyy6coIHxiiNCmnm4uVQMNT9EueGhO52QfxO2hYFsApm0veKkAIpnnsTGQWtCypYBEYO5tFR0p+o+yrUGRismqk4OFwxlpbrLlIiB7iQ2ZVMwTGNedZZCsiuMt/KdZ+wAC20AXIZhaG2rDS0lE5WmVJlJIsZpaSYaho3edEzixo7HcqwFC5dZ7hfsqQyRWK0YNEXZ6KjgVRRl9T5QLBNd6bhU6HhEebK2dMPX6WJzARjqYuLuIl5SHuqPWRjIpTBR8jAxZ+MKBpDNAENxU5IWdvVksaUnI7FTHg+tZxPY1JPEub0tPzDXN+C0/JxBGIjY/cStD2HvCh0crMAuFN4LYZW3K82BDEB3nMMbWjeybCCbBZJmTCq19P+aYQyGwVJwy87AWLFSs3U/XQA29bYyfdkUt2e0goNTVVTcUJqtzh9oZe72ZOIyTphNh/FYq4Lt+hHKVRdJPsczAmuuEF0M7utt3SlcsrVbKq4HaS2wgJ5kQu6H1dpqw0HSNnBOTw4hq7cwMVBIia+2L/PIZi/JyA0jietq+GwiYyJGS/TNXbK9XRS71YYn4rjqcFSvj02FtNxmU08GXam42DuWE7N2OsXmyXh122KfRxaYJlFIzq92K4pyDH1nrDUs07zgBcfOK8o6hwLjnoNF3LF/HAdGTjWTYWWcmwPe8kuX41EDhUdcJ8LEhIzRpf2APlhp/OLktgSwddDGjt5enNuXxVW7+rCrPyORUITTuehjZRVwrjBqezNv31PCZ2/fg/tGjj9omIfM86waJyGCL4gMJGI2MrQceD72jXKyVmu8LuH2UbpvGYijL29jZKqBiSqbuYA83QimgVwqKcMUaBUY6s7AdQOEZkqeBwrUI9OBJGPwVJbkhphUW5kewMc1Wm2KWCrWXaQsE32pMnrP6cOO7gzS8Zg0kdE6cXCqhkcN5VBseNLARn8xp5/ZS0R7tUXcUFdacnHPHcjgoZEy/MDAvokyvNAQuwS9w2xAY5k6lbCkQe3wZA3nDWUfEcNVrDXx8FgZVSeQ6DhOQ2NsWVeq9aOEU9Xaz1HbxjBe8vDASAnFqgvfiGDBEGvFrr4MulM2UomYCNbjNY4txkqXPx2Ijcijd54/avjaix6ROKEoZwyrs/WMCt61hi+Kyy9f661QlFWBX/6Hphr49v1HcNfe4rwGsNMFLRO7ek3s7OvCC67YjqecP7joF35L1EQ4OFHBvpEixpvHrjviAIVGgIs353HNOf0YyCfF37lwPXx8NceT8btUyjKFzfdx18FJHJqsnzByjXaLC7akcc3OzdjcTb8qJ51ZqHkB7tgziXSihJrrIPAD1EMTXtNBImVjcy6JXDyNsGCjK+Oh3PRwTm9Oqs6BpBZYKDkNOKxY00KAUBIDKCQbc+6fV9PSkUsnwLkbzcATweq4Hvqyccm+nWx4ODrVQGFrXLaPubJHJxvozcRRabS8GrZJ+4EnntpG2UUzH2BLIb2kt5X7kj8yKMweGi3JyN9UwoQRGdjWlxbB2nRCTDYc9GUTMio5w467GR8whTn/vf9oCT85VIRlmWIpeeL5vVKdNYwI4zVXGsVov9g0EwPG2+wZr+LnRyoSyUaR/MQLB9CTSaA3F0NkmGLZmBtfdqKYtU5qNONrmj9WKHYZH8fJeGuxHYqyHvSMvi8URVk1+GXL6Kr7Dk1j8gwUd3mIfuemFC7e3CXVwe4MExMW92Ky4vlfdx/BZ27fh6NzVeAMe8ZD6bAfWiB225m9RhTJoAXaNTgWty+XlMPiNSeQoQTpZXya0mvbnc5gW29SKsgDXWkZnHB0uo7JclMGFHBMbjpho1J1cO/hEtwokKljuYyBAHGUGgYGsyk8+aIhbOlNolJzMV5qwo1y6EnHMVJuYqTUxIMjU2JnmOuhZs0lmTBQbjri/T2vvyDT1OJ2TIZKMGGDVdXRWgNDtZSkDnByWz4ZQ6nKGK8IBycjxOMxZGxTxupmWV31fXQl7UV9020oQDl1rdpMI2O7MjK3Px/Hlq4UhvJpEY+cNscfE1wuaZtSQXU82hBaXl36fWmxYLWdURR8vtL5mEw8czxXUicYM9ZuQGMV2gkY/BbAstjwxpHBIfoLCcnYZUPbYvFlx4tZ66RGM94vbQz89UWxy+i0tdgORVkPqOBdaxhOuXt36/x553XcKD5FWQn8sqVomigtNkx39bn8vCy2FPKouxRPKfTkWlO2FkKx9J0HR/EPt+7F5BKbxgPC9xyawDMu2yyCty12h8vs6g9gGIY0OTExgIfRaw6FaUwOyZ+3OYtHF/vQ2D2B8Sqkqtq2S2Cu2EwDvem4iGXaD0y0JoLRM3veQF6SESwrIXFbHPnblUuIiIl8X2wEkRWJQM4nDaTjrWY6JgxYMQvdCUvEo2mZqDQcNNwIrsdJbEBi5sdHd5oVU6DqRNjVm0R3kikISeSyCUyUmjg8XYcXGMjaFhq8z3Io/l1aGqYbHqabAcrNJrrSKSQtjr+1ZMJZKQzgcVTbCeB+ZcrDZNVBzY3LJDHLaDWYURBv6U6LtziMWj5dVmhZgS7WPeTTFNQ8b0mleNtQHlu6U2Il4PPLyi7FLv/ljxNW4unz7U2nkE82ZGjEeZvyGJwRuxT2nE7XFqz8mw6V5XpyT7bR7GR9v0vdrm3faF9HuN+0iU0544SdrWdU8K41TIn/9Kc7dhSfoqwECsTxcl1GAJ9uem2gN5tBb9oWvyenqNF3upiIGCvX8bV7Dy8pdtv86MEifnzxJIZyHHtrtkSXFyCXtKVyHbdaDVI8BM/D+eIxTcTw2K09MnTigoFu3Ht0EvsmqvC8UJqxaBZmCgIjwbZ3J7FzIIuebFIO08fsVjZsIhWXEbzbejNSqeOEs0wiLkJvut6EHYshFoXos1of2RSg3Kaphice20cN5aVKzMYyDmCgZ7Y3nUAyZmKkWEM8Y8r0N2rSRDwh0V88nJ9OWsikk3CcAPlMHINhCNeNMNidhuv6GGsGmKy5sk2TjQbqro9i1cNYsoHN+TQSbgzZdBNbupIwzGhZgo0xYtx3c20hbQ8tr+f+rrqBRI9ZloHkjJillNvRn5WhDhTX+QyHX1itQ/iWKTaGdiW+wSl/Uw0R6ZwwfMnmbvFsbyokMVCgyG790FiYz7vSL8WVNpotNpWQRyT4WjheA2D7dqx2yw8v24I989ppe3ZjHeIrVs5i/M7WMyp4FUVZNVhFm6778sFyouSBU8Xz6UetoSsdw0WFLqk2UsQshF/+4xUfR4tLhN3OYSIE7tgzjiu2diOf4aHuUKqlkxWO1TURs1lZbQnduUJiqJCWCjOzea+d7MXu0Rq8yBcf6kTNFcHth8AlW/K4YFMBmwspaYibK3CYbZtNtbZ3uuHCTQe4bFs3Rop1OGGA4ekm7IBiOEIhYckyeVb3zAT2TVaQnDkk32Ub6M+1khHGKnX0ZVPozSYwXq1jvOpgtFSH78clo/cho4ijxToysTgStomdQ1kZOsFCYcWLZHjIdL0leOsOJOXCC034DR92lykNX2wS49he5uYuxWJCjPuwPRWtNd649S9HJ9NPm5xZN20S/JeCkMtSJDecEMWKJ6KcNgZWwbnOJDN1/QCTdVca2xi7FpkRtnVnUEjbGMglZV3tOLO5ovBMxHvN9f1yyp/rGzJKuemFSNnm7ONYbGxxueHIuGJOvivSF52KyT6fu3wn+IoVpVPR94KiKKv3gWJxUpgBDsbikK7TSTkCvrevisgIsaUrI1VTjsBdiIhgI0RfJg0sYwzGd+4bQ9q2YYQBKr4n1oKkxaEIKTx6Rw96diYeIUjaFTaKOFoezh3My+WSglBrYrrShBeY6M3E0J1LihViKVElh9dNUyp423tSmK47mJ52peGu6QcYKiRRSNnoSyUkuYFVTd9PSRWUloHJahPb+1KI6P2NmxK7JX6KI6ZUROlrNdAaEDJecVGp+bATDmyTE8HYYGbj0ISDg1MlTNYdBKGBTQVWi4GEZYvHmdaLmBVDNm7DjhnIJI95WNsCViqoM3FfbSFmW6ZYQShoua9Y5S3VXLEWcJQwK7qTlQYCw0BvysbWvoyso72vmMTAEcxHpxtSJW76JnqzyVmx2s6CZjl4stFExaVX2JeM4aSdk+cjoP13gSjEGaqMzvX9stmM3md6iytMyCikUGu64kdmg1/7R5XsT48DNHxUGoEkU3h+iESsZeWgGG4L9U7wFStKp6KCV1GUVaOQSogoPHf3CEoHGydMLVgNvr+3jkJqQqqm9d400sF8scIvfR7iv2JHD76/u4Q54QyLMu4C/3jHkUWv25Hbjzf/4mNw3fkDs9PGFrIwFqrVrJUSMU5Bt7A63Ga20hkEIgrZGMfcWDaT8RA9f0iYoSkjeIfyKdRDH6WmJeKsqyuGlBWTaWhDhZR4YC3Dwq7BSOK42MFvGwb2T5ji8W00fRnbO910EXGGccxEdzqFuw/7Mtxi71gVdfGBmrI+Nuaxgh34oQivdCyGkuPIsI3+bAGpuC2ii75ZZveOlB2pCvfnk9jalWo9XqM1+IHlY6sJ1A1uvyeH6JloVmti1lqRMmNIJU3kE8cGXdAuQ4sCp6dRyNsWK+QcJuJLFi+vFy8v/czJOAYyKSSMGHrSnlSBaQfgaGQuy22ZKwpPd2W0LUxJ20ZB8c7X2nStKakbXsT6LZBqeLDtmNhmmGktgpxDQXL8EeMgxlHINqRCzOEZdb7JZqbJ8bVwsgMsFGWjo4JXUZRVJRezsKkri8HxBkYawCoNHTsu49NVqYhSLC4UK/zS78/EsbM/j609BnZPrWSQ8HwOVIAPf/0n6ElfgSu29y8r5H85uagUa2MzQrGdCsFRuw3HF9tA2vFRcgKkU3EZzjDVcMRLzHJtOp6B50XI2oYITwq+VnxaKOIzk2STXBy9+QQevbUHeyequP9ICfcPT6MrGceY5yB0DDTsAPUGBXcTxVqAZtD6gsgnTeTSWVw02IXxSkNyeG2LVcdIUhrYZFatexim2yCMcLTYRM3zUUjFUaWQCxkRZkqjmJto2UGmKk2ZAsfHSpWXT9rI0JLCGDU3gh8PkE21GhDbsWQUx5WGN5PbSy+whZ58HBkrhmlGxTU8SZsopGJSFR5kwx+rp64Fnxm9Ae8ngh8Lxf/cFrvy3MxUdo9XGZ0rWuf+aKk2OK0uQsIyFv0RxNsx45j7jdVbJl9wBDFY/bZN2GYcbhCiO5WQRAw2IMZMY/a1zMfu8nzA5kZbHhtFf8DsCTYygo8nPivUZdtW8JpWlLMFfV8oirJqlBoOHp6sYkpEQOtI+pkQvIenXIxX6tjJpi8es18AhQizdc/f1IUjU9PzsmlXyv2TwGd+eFCq2Zds6Tml7abgqzgexopNyZFtzjTITdUaIoboa93SnZHLOWCg1fDVOszNKi+b2mLlBrxMQqwFWSMuSQMU4hwFTE2WS9hS+RW3Rwy4cCgvlVFGdB2aqsAws2CUL6/O5kxMlTlKmJ7ZENm4iVQyiWbDw4NjReQTCWSTJh4erUuluSfJfOCYDLEYLjliVRgrNgAzQrHh4MKBwuzIXgqxdNyWKrYfUZzTD50QDyurmZy65vghsikKTiAh+bK+VKtbh//ZyBcTO0VPysZgV1KqtbRdcCAHH18qTmHroSeTRCIRw/YUp/758kMijOjt9ZCc8U63adshFjawzfX0Enqmab9ghbpdfeXzt2eiKvFm9HZzaEnbwtFuRBOhHAQiYvkbhT8C2ikRzDPme8ZAy67CJsO648ExWTmPyzoqri+T4jikpGfmx5NlRcjOjEw2DLUwKMpyUMGrKMqqwUPwRyfqqNQclNxj+a+nm1gM2NadRyYZe0QOL6dz7R2v4ts/G8b+4eIJLQ3L4Y59E9h1bwaD+ST6cvQGrxyKpcPFhkwVOzhZlUEKFLDdmbiI19FiDaFhwowiaYob6kqiUg9EGHFYRcqOIVWIoTdno9wMZIgDD9tTePGDnT5h1iPFl2qa8D2OoA2litqViePcvoxUhadrrCTSP2siZ1uodmexd7qMeqMVbSW70zLFO5uzY+jJJ3Dl9pgYtguJGOpBIJVkitKRYkMeh83wCg7DaHoi1NvRWTzcTlFMQcskBtoeuC0UgM26M2spyKRtVFxP7pMC3zItuR2tFRSNFJ3hTKQbK5+sghdrrKJGGDBbQpgVcLGQ2K3b0gdASwZ/SLSb1lhdpr9XfgssaGCb6+nl7Zn5G4uZsnC7+srKLsXuYD6F0XJDBogwq5mPud2IRugDrzut5y4Tj4knl4KXPuScb8uwjVKDucKcFsf9EqKZbDVh8n4TPJJAq/FM0F27Gs0mt3bSg1oYFOX4qODthMkkz3/+sfOKso6pNX1M1VpDBU7eOLBydg3mUEhZ84L3KVb+6Xt78bkfP4z7xlc3Jy1tG5iouijVOYDi5NZB2wKrnbRiNDi4wm5ZMWg/YKRZ3LZk4ETD95BLWIAVQ81pSOUzFbMleSERM1DzQjmcfygABrLxVpPagpzYWpPxZb7EnTUcD/FYDAOFJLb1ZRH6ERLx1hQ6HipvBiHOb+RhhBH2jtRwoFhBzQ8RWUDZDdBrAPGELcJtU08SRmigErMkRYKRYCnbwL6pGrpSCbiHS9LQdvGQKVX2tr2DYi83xx7A54p/ti0FrApP1nxMVR1M1Txp1OvPJRAakTTs2bbZGjpBMRvjAAyKeo5tjsO2aH9wxM7QcIGm78uJ8+fYlMfxw7QI0HJBr7QfBcglEiJS2z8WFnp6OZQiTqFcowXDQNZqvc5oY+BtKHb5L33SvF3TCeTHzCbOkZYfAKxoW5LM0ZtJiBhv2w/SiZnxwEEkU9+YcsLKPB29tHosvN+V5gUryhnD6mw9o4J3reGL4ppr1norFOXUsnerDZTrAX56qIgDU2WMT4dnpGGN9MeA/3XtOdg1kJv1VtJXedM3H8CHvn/otNxnOpWURjhYJy+kKepYhWXkWZoCMEkxaMA2LfhWJKNw6dfd3JNGPhGDxSqtH4lwYg4tq5epBFMaPAz1ZKRSydg0qTzODB4grWqlN/McuUgn48gkmGGchh0zpRpKqwQrjHsnashZBioNV7J/d27KwEGII5M1BGEIy2TluTnTTGbACEwkEqZUTTm5jadSzUMkvtUmkEriwHgNzWaEVJLe7gS2dufm+Zq5fRT/rApT1LIJjZVM+pebYQTTZHRXKPFo/BVlmCbiLpDpaeXpsjLNzGLLpI0jjukmK6URwjCEbYZIJ+JIxnzkUzbKdQ9jJUcqvLIvUjEEHu+rIZXgth2mLSRbloFW9ZS+27hsC8RHK8+hbWFHT1rsBhS/vM3Do2Xce7iIus8UDBvbu9PY1p+VJjXuU4rduf5hqSrT7hBQiMdwaKqGoUKGKf5y391JW4T9Qu+wfnkrHYfV2XpG3zOKopyS2L33aBE/OTSF0ckm9lPslqqonqF9OmABb3z+JXj6hUOzDWTcph/unsA/nyaxy/rpFTu68ehtPUgyGWFGwKyU9qhdHvamXYFDiqYkBiySQ+QctWAakQhjistWxFgMRcZsGUBIoehzApyUJCV9IWFaKDseQvqnWSU0gKbTyvVFSI+1J1VLHiLvz7GZrFWp5PZLc1gQYN90E6PFhlzH6DJWUJlha1q0UbSGV/i0EnghRsp1bO5KS2WdE9Souh12h41H4tOtN13sOerh1vI4YjFDBmQ87zGbsLM3/4iBCsyXnQ58sJjNB0Vh34cExoLWlLSUbUu28ZZCSh4zfyRIJBtHBeeSkgDBZAlaNizLlgY3CnEYrlgeaNtgq1coOyxCiWOKJaYtRDYdFx9t2w7THgrh+qZcTx+tiUgsO4x0kx8UrTLsnPG+rRQKTqsbqTRxXl9OxDu3cbrqiqDuYpPanIERs/fFfZGMSzMep+XRA80x0e1INq3iKsqpo4J3reG33MGDrfPbt3fcKD5FOR7MiH1wuIyjU005bH6k3PLunm7oInjqxd140dXn4tJthXmCgJXMWx4cRvE03Tcf3q0/P4pt3WmZnMbmpZUKknazGi0NFELdFFymIdXSKIRk6cbiFFxAo+Gh1PAx2JVAjh3+LM/OHHZn5i+rkKz8UZjy0Pgom8fiFhqOiyAwYHHa2lRdqpq0A/B+WFXkRLa52811JBM2XL+G7mxKBOLBqbo0t1GExQxTKsLFahPDjaYI2GSSww9MdGfSOFysS2U3m0nCsIBKw0e5YePeg1MYbzjYlEniwZESLtqcx1AuPS+flx7jisMKpw8zmUCt7EimM73K6QSnvgG5dAxVx5CPTBaSmHzAinOTFgU/RCYVE7sHh4VMVJtS0WV1mEK5K9mqzNJqUKw7EufF7U8lTExUffhVD9lUTKqwhIKU+4n6l3m3oyWKbg/TNV+EaCzGiXZx8YwzVswPbHkMFMTcr4PZJIZLdWztYT50QiLFHL9lX5HpfAuY52+OGfA9IMl8OB0TrKwnws7WMyp4O2EU3yc/2bGj+BRlKVrRV/SE+pIJOlVrShMUB0Kczrj7HhN40TXbsWMgjb5cYt7QAZ6/9+A0bn1o5LQ+cfuqwKd+sBtGZIrgbQuk5XgqKXb3jVdwuNRE4AfY3p+RlARGdzW9lgCMWzGk7RhG6g3kkzEMl5tyPywkMqeW98PK6NzGJe4DikBm1SYYbRa0GrrYaMWIMcZ50QJBjy9PC7eT29+dtXH+QB57x8to1FtTzHrSMRTrPoZ6GBNmwYgZqEw1JIqMCRBeFCIZQUYZs6K8qZBCsZFEue7j8FQd9xuM7DLl8Z4/kEGtGWC02kRfphU7xtfKGEcvu77Ec+0emxThmYtbyHLccT4tH4u0cAzkEpJcMckpa0Erus11Qym7M/HAStBTayJmtPy5rI57AZvATEmq4Ohl2kFMhOjK2XzU4kVmo+D/395/gEl2l1f++Ln53srVeXKQhAJZBJPWRINt/KwNeL3GOIAx7H+XYIMXWLzrgMEmeFnjx8Aas4Ajixev0/6wwcAuYEAYWSQhCUkjzWhi565cN9//c97b1dPd6p4g9UzX9Hw/elpTXV1ddevWrepz3+95z8tmMfqh9fjs2F/+y6gwNqDxuVtGLCcAWqyjiwQzTV+quAWL0W2ODM9gCsSumgfPLmHfqIeikx+j3D7+O7CarI844xdfQ64aWLYuPviFlFPn8p+pMcGKoScebj2jBK9CoXhI8I/ziaUujs93cGapK1O0DkxUZQoUx/E2040rs/zQWXqI+5y/f93eEjRLk1zV2VYfI6VcABJWED/25e/hROvSv6gnWxC/Zctn5Y6Ts9Z2+q+GYo55tVweZ4PT7SebsjROyRPOdFFy6KXNkwY0Q4eeZujHljRXLXZTEbsUZLqWR1Ul+tkBBvye1Vv6bhc7EUzkDXX1oiGRVZYFJEmMhSBDMYwxWbGkGrwe7kM2mtFPWi5Y6PY5ba0nTWOjRQtJosvUuLl2IJPgTjVZNc5kGf6aXWXsHSmg24vRCSNpCDO1DPNtDXtHK0gbLdQ8HfuqHmxLw5HpJhYKuQ+67OmSqWsZHo7MthhVK1FlM50Q98x2MFHpyXS3R+2ri81hftGXanCaxJjXMxHybEhb6AbwI0PSG2gjMFn1NnSpgjP6S+LQpJWS26zBBh9TQw8J5tu0HGDFD8wTCe5b7uOersntZEKcaaDIcb6eIdYO7jMm4Upjmq5LU9p4OX/9B1PmBvm9TGbggIkwCZBQeDO2LGNl2pKThYG9ZDCgg4Le0GKMll3ZdlZ/lbVBoXjoKMGrUCgeEscW2vjfXz+Krx9dkm74LAFG3Jbk7m4kdsmj93noRhGWpi8+nbcE4KYDRalO2pqG3VVGgtko2Wcb1T733WncevLytMvxGfSiSAR+lMSoFVypdK8eDTvd6mK6EaDZC2Wpfanfx9JShFk/RMUx4BUsBJGJZg/o9iPUS65MNlvoB+IrpU+XwxRoRe2FEW450gTjEvaP005RzCdx6Xllm2KLco6iMEktqTJySls7yMOsaHNYYHRXN0a7nKchrBZQA7HOtIFdFZ5AlDFZ7WKxEyPVUtxxooE0TqSBjTKPVVF6V5f6jKLrIghjGXxBW4Vd1aXyzKX8m/YA1+8uy/VjJQ/zLR8nFroouKw2m7h+qoqpUQ+epomwpe+36Wc4Pt8CY29PN3s4MFbCRM1Flroy2ILWAa4sXDtZgm6bWOhGcJlYwTxcx5AJb20/EgsGLR+5JtXkcooMRUtDI4gx1+3jgQUftp5isl7AwVFj7QQ2naOyDeyuWyKamfxACworx5x+txj7MHVDKsb5/doPsrgM/NEiuBOe8PiSMFFyDWm08+NQ7mPwerBBrWdy+hyTKiKESz2pzDvh2XHDCoXi4lGCV6FQXDT8w33vmRbuPt1Eu4+VQQ6d84TcHjnRRyHvV7oomHT75OvKuPnAhAitR0wWMVIuiE+TnklCsfPAXPOyvZo1VgR1QwYh9KIUp5b6yx5QTaqY95xq4n99834cPx3DMoFrdzuoFjwsdXvINEs8tiNcoo8yBFkKO9Gxb6KAA7WSRJJ1/BhnGn3xqVIE3jvfxNG5LrQUeOSBOn78iYfw1GvGVkQQG7/oF2WjW8E1peLulV04doTpFjNoM0mFoCeVgitx106kWz1oYSCqdlWLKLmxVByZEtH02SBmQzc0qZ72kgyTBQOjFU+sCVNlFws9VktZZ2aEmIluaCGKY9QLTEmIce9MB2eafYkPo8e1UrBlbPF4xZG0CApHDV34/Rh3TC/JgI9jMx3sqhYQj2WSakFbwVwzgMWc4kn6dPNIOiZbaDAlgYGdbcz5ZYICxS6r0gWblXJWgjOkIYeVBDix1MPeWkEayw6NcAy19aAJbExWYJoFLRusaPO+OXCjMFLEroQ13mzNmOI8LDhfBeExwTxiNgyykY5VZENPsdCJYOgxdtUKaAehnGiweY33QTsKM4iZy8t9TRGdDw/Z2pHHCsXVhHrvKBSKi0ayXfsJwiy9qKlls0wnaOUClq077VU/YytWjV5NDTgdrP2Q+tHHTuLFT9mHisehAgbGSu6DPbMaY7MuX/Yj3WnfPjEnTXJJkshSPqvMlYIr+bhfv797dshFDMwdD2AjkKY3Haw0AvpMJEKRFVjuk8VeF53JEBXbhWYB00t92VFHZ1pYaAHd5btrf29J9sF1U0XsqZZkuds2cn8u94vYHii8WPE1dBwaK+OMVAopDCHZruunja0etDCwZZxtpvJw3WQRiy0fJa8gI4X3j3kYL3iwLE38xnGSD1agcMuTEpiPC5keJlN1E6Dhh0hSZsoyGzjDYpc2AR2ZvhwHZhgi2osUpkmK6U4fJxY7cAwLJxd60tzHaimTEBjZxYr6qUUdj9xTFY1J73PGfDYeS54lAyK4c8uejYVuHwzy4OS6lu8jjA2ZYNf3GVXWQ7VQER/16qay1VnG3DccMsETCTaw2Qbj3awVywIr2Dx50fT897gZFKm0hIjX2mQlGGj3fARRnqJBawUtLnz9mHtMWwP3GTebyRK0diz2fERpgqlKYSVjWaFQXDxK8CoUiouGgspg5usqYXqhsAa6qwbcsKeGJ++fgmFmCIJUuvBHy46Ipy/fPYvP33kcvRg4PFrBcx69W6qNrKQNBhUwr3Y1JcfGjXsqqN85i6XLMM94JgJm5mLcObc+D6K36e8MAiwGjo/Vzg9Gud27xOSLJmqFlsSTNdviYBCBtPpe+ylkafzeMx0kEaSiy5QAGW5AxWVo6PQ43jmRZfj9dQ+7qrQEcMhEHotFkcYv7s/1gxZ4/aA6mWnMBtZweLyCRj9BpxfD9fIxursZobUM75u35fAJphFwCX8phVRMj853UPZMLLUDaRqjFncc4JrxAuqeI/FgHHohVUxGrOnA3rECbj+xBL+fInVjEakPzHfES5tAw0KT45f5vFnxzVArGDJ6mBVgGgwa/UjsLgYHN4QxLDadmakIcGgOwiARewItJPz34EhJqsnrEeG/XHnlNp5q9GRyGqvM1SgRe0WH6Q+dQDzCkmghJwt5Q96ZRU5gi2Rf0k/MJj/GTNCCQb/xeMnBdDuPXpvrBFJNzjLux9w247GJTWf1On9NFArFFS543/Wud+Gtb30rfvEXfxHve9/75Drf9/HLv/zL+MQnPoEgCPCCF7wAH/zgBzE5Obnp/fCsfyPe85734E1vetMl236F4mqCf3g5KnVQcbwY6jpw7Z4afuSxB/D0a8bEn8gmt+MLPcy0+7h7pi3NXddM1bDQ7SGIQ/zlrcdw7UQZu0YKmCx7Ege1q+5Jk9WgGknh9uRrJvDk+2fxxbtba0YIM8afUoHV6GGXDM2AI5ozETui26mP1t2mqAO7K64sybNevKfuyqS0SsGSRjDenoKPDWj9MMJEyRE7w6CqyzQH/pzKs1q0ZXl+MK6WKk0mrsUBFjr0l3JCmYnxoo0bpsqyFG8bkJHA5/KUUuBFaSq2DIrCnp/AsHUUPAvjJU+EPFMgWFW1OLSC1X/LxGzDl0xh5vIeX+rKMZG2IZPUDo0Ucd1EGc0gtzOMFS2xfMg4YoeT6GKpLLMJLIhSlD1rRdBTkLOazJOAEpMTnBRNP8bBiSLCgNnH7nn9sf0owkyjB51WllYftYKDiKXrVEc3ZlavJtvLKjJb6XhSMtPqYp72BcasxZzM5yKOUnRSoO5Zsg188pxQyJOTKIZYYCj66zYtIYlUgDmyWaFQXOGC99Zbb8WHPvQhPOYxj1lz/Rve8AZ86lOfwic/+UlUq1W89rWvxYtf/GJ85Stf2fS+zpw5s+b7f/iHf8ArX/lKvOQlL8FQwk/BH/iBs5cViisELg+POBqW/AuXkHtM4P/3gzfi0furuHa8LONmp5sd/Mv9i/jemQ76cYx7z9DokGC23cNSJ0HXByL4uPPMEg6OlvH4faMYKeX5t5ygNRgHS7FCUfzz338jRsoP4HtnFlEyHTzxwDi+7/pR6JmGZhBJcxgnYX3yaydxGcIcLhq23EWbNO2xIjxWAapFC1XHFkG71OvJsvdYyZaGLS6tu1yWZzWQntIkQTuMECzbFSieKPr4u/w5/byaqz1o6Z72EP67t+6iG0RSvZ2qFlAvro3TWg8TKZhAwEols20PaEXx1HIbsl7ukaUVoNkJMdfypborObqOJZPlFnsRiq6BY/NdsRqEEVMbmEfso1xypJmPgnDEc8H1/4prSDYukxQ4ipeVcT713K+83Ay2vG2D6C8Kfz7P3TVX0hPGPAOl5eERG8Hb8iSBDYinWz7KtiUnEhS8HP+81I2kMl0tcxobZCIbVyNYKRdbQy/CaMGQy6zcTkqucYZayZHoUs/xsNSOZARyEqQwUkPi5HhywNeJ+9Nd9ggrFEOLMdx6ZtsFb6fTwcte9jJ8+MMfxjve8Y6V65vNJj7ykY/g4x//OJ7znOfIdR/72Mdw44034mtf+xqe8pSnbHh/U1NTa77/27/9Wzz72c/G4cOHMZTwoHj607d7KxSKi4JC4vpdFdx8eAL9IzNYbOdV1IVz/M4ja8C7fuapuHGqtiKUTi618U/3zOGL35uWgQmMJo3jWJa/s8xAw08wcE2canHVpy0tTTcfGJEYqtGSu0YE0AP5hIMj2DvqYLYRwrJ07K15qBXdNV7Vw5MliQG7c2YJXQ5uMAwstvtY7CQIEmAhH0w2NHDflrjazgljtond1bKkQtD/SbHIJfDxoiNd/R5zeS1DKrcUsxYrvhpW7AoUmHy+FGxUhsXi2Wlrg6V7RmKxss6TCebBUjzS1jDYhxSgG2UON7o+TjV88fLy1oz1YhsZvbeWYWBPTRfxSyHIwQ/0G9OH25wOZbocq8m0RBQdF6bGTF0DrhWjF1D0arBMAzdOlcWCoGmZJFD0g0imwLGprOzmDYyrm+/WN+MN8pplcIfH+2d82Lmnmcm45iQR7zNTFDiUg9V004RYcCqeKScP/K8fswocoBFQIPdwailAx2dF2pImRU7VK9k8vvP75uFraDqm6p5Mc1sshOj4CeolTn8DnKKFsuPI4IrBJLiNGgwVim3HGG49s+2C9zWveQ1e+MIX4nnPe94awXvbbbchiiK5fsANN9yA/fv345ZbbtlU8K5mZmZGKsR//Md/fM7b0S7BrwGt1jDWfRSK4YF/ZB+9ZxSvfpaFZ98wiVYvQq3oyAQqLt/+zTfvxR1HI2lK21sAXvz4vXj1826Uiu4ANnjdet8ivnjnjHg1Z3p5I9hoASgWDdQKOkqLQLAsDChAqSvGy44kBsRRgn++dx5HZpbk+0fvp9AtwDU4ncvAwfGSWCMokigQCIUWRQWHGTz52nE8/uAo7plpYrbpY6JSxpHpRTywQA/ocBEt+38ZT8b0BjaIUagv+FzKZyU2gqazwYo+1jz/VaqZbraS0zuI2+LJCr/o992oUrs6nqzm2iseXl5/otnF8dmueE+nyrYs3VMM82es7D6w0MP9852V5qrxqbJ4T0crDhJ6a9MMY2UPaZpivtXEYhSh1Q1RLbjYdZBVzlCsCXy9btpfxUxjAv90ZAZFh5XmMnyf1gBNUh1IrZA3jK1/HuY5mvHIXNfHfDNAN4xFNLLqzJOGzabm8Tb8kqY1nVm9lkTD8SSDIpfbJB7fKEFvMUGQMjYtganxxMNCJwhFrGrM/pX0CMbMJSjoBuIow2jRELHOx6Zwp82Bxy4VLx0TFLu0ewwq0xs1GCoUiiEWvPTmfuMb3xBLw3qmp6dh2zZqtdqa6+nf5c8uBArdcrksNohz8c53vhNve9vbsC1wPWtgw9i1a+hG8SkUm8E/stdN1uRr7fS1CM+7YRcSUFzq4ptcP8aWMJrqG8eXcGSmgVPLHVn0rNZZDd5VR8kykaSnsXDqbAcaI9DomawXDHz+rlP4x2/NYnZ5/b+GY7hmj4m9tTp2jXiSYkAxxkqcnlAwprIUTTGmGylafogzS31JA+CI5NNLXRyZDobK5qAvWxlYOJGhRSng2BaCOMViEIpQY5QX9zFF/ljFXYlpW7uU/+CK4EYiaVA5pEimQBsMTuCSetPv43snmzgy05URwnfqGq7dVZK83/GyK+KMJz5MG7hvroXdtSKSNJVmQj7uSNHBUjcUn+tiL8S+sYJMMONz4GMutAKJnNtTc+FYlojsCp8bh010QqkWc9gI7QP1Qrwi6tc/j9XVz42a8VgRZxYwp6p1+jEKniHJCqzgDiLFBvtg0CRGMc1KLiuz3mhBEiFG3DylgeIzCBPZDhZgabewGOBr5K8bRzKPV13xFdtmCs3In/9SN0A9ciXCbjC0hAyeF7dVGvn0VHpTBpPfxCax6jmpqDLF0JAOt57ZNsF74sQJaVD77Gc/C9fNlxu3mo9+9KNilzjf/bNZ7o1vfOOaCu++fftw2UbxffjDQzuKT6G4GPgHuVp4cKf7elgN/M6JBr57uoHF3tp6Kj8jObKWuay24UJDZ6XRjHbhLNEQhMBdZ5orYpcwK+G2UzFuOzUnleIqm/EZwWXmsaisZ5aLOvaMVODqGs40u/D5AZ0leGA2k5SEYYEL17ssoMfiZQowkKJoAuxvYkWPsWAV28aekYLYFcYqDq4ZL+YTzjYQsqvF7/rXgRVjnkQ4uiF5wLRBiA/YytMc/DiVhrjFXoD7Zzq4b7aJU40+koyvgYORooub9lVweKKMjBPgXAsHPBO7Kh5Gi65YFHqhhoWWj1PNLuIIaAWBWCuYuRvHiXhhaXug2B0rM6AtZ3+9hKdeM467zjRkW2lPkfQKf+3gjIHIZaNcl8kSWSa5vGyGo/1CBoJoQLOXit2iH6UwWT3VMqQRI/ZiGX/M3+9lTMWI0WUlnTboLIXDODedgyKYRmEgZAWXCRjrxCer4iNlF67NQSQWelGMitPH6XZPni9PwDiOm2Ke20Wfr2s+uEI7ELaMP6NFhfFkAzvD4KRl9YAMhWIoiIdbz2yb4KVlYXZ2FjfffPPKdWyu+NKXvoT3v//9+MxnPoMwDNFoNNZUeWlTWO/T3Yh/+qd/wt13342/+Iu/OO9tHceRL4VCcenJxe4iPvfdU7j7ZPdBIV5hyKoYl60dcEbY6pY4pizcc2ZBqm1JPAj5ejD8yRx1NJ1Kq6PT+inuml8fIzZ88DnzI6lg5x5RpgLQtxqGCRyXkWBFPP7wCK6ZLMLWTckmXm0XudDX4Z7pBu6ZbqEXZyhbOjzXFmtKuxeIPSRvGMuwu17AbCuAZrDaaebRWazSd0L4cYapmod6McbeuoPYpV83w3i1IF5iClFWeue7AW5/oImYKRB+hIMjrPACC2YoIhAGo8UseHa0Yk9gvNn+sQImqy5ONfsiSjn2mMv9g8omrTHT7QD9KEaaZLK9TKroMft2WbTTSsGGMU67o5Av24woMzBStEW4s9LMryZTHqRKa6AXBdIwxiEVc+2+DMhgKxoF90Q1944HEfN3KaJ9aV4jTLxg8xz3b9rOpEGtF6eYqLiy/Wyuo/Vhd90FzxDotR5E7a2uLHPVgRFrcRZitJCvTKzPBlYeXoXiChC8z33uc3H77bevue4Vr3iF+HTf8pa3SIXVsix8/vOfX0lYoIA9fvw4nvrUp573/tnw9oQnPAGPfexjL9lzUCgUF087iHDbA0u4b76zYWJtJ+TY4g5MjnA1HpwAwdjbe80FTI5WUJ9uYmmHvghHO8C+EkQYcuQwhRk9pgvtPsarnuTU7qoUH7J/k5Xd+2Y7OLrgY7rVEZXtOQ4Oj3gwLQpPC45FW4MhHudqycB142V0+hEmAxeL7QB6msrksYhDHyxNspIpMslggAOFH0crzzT7MmCi50dSMT7d9OX5lJly0AvgtQ1kSUcsApNVD3VpttNQdG0YRoyp1JGGwnYvRObZ0qxGKwEzfnkssYwfpJmMJ57vBKi6NjxHwy5aKzI20WkouZz2FspQh+pyogOnoBVsXeLMKGBZL2XknsGmOD9Bux+izDQGm2YMHVWTx2XupV3iyGhuFDKUChbKqYWYU/M0hpLlKRm0NbiWLskZbNTjSQAnv9EtUS0wbcOUai6nsNFWwSlrtDAstkNpaGOTnGnlDX7nq9grFIrN2bb3DL21j3rUo9ZcVywWMTo6unI948RoNRgZGUGlUsHrXvc6EburG9YokOnBfdGLXrTGksAos/e+972X8RkpFIrzQfHDeKf5Vg8dTlPYAGb7/svRecy2GUsVyASy1cK4kQHfmYuxq9kUcbKj0YF9I2U8cn8NbU4Ea4V40rXjqLg2ytaDfdEXwsBnzYSH2XaA040WTjR8GT08VY4kUsuzInDI70TZRWWiJB5TJCamRjzcrI9gtOiJzYCT00qOhZJloGgYUo+nSKU4E6EbxGj1IxG0VG9ByLiyDOMFG6NVT0Q2BzEUbRPTzQCnlnwsdH2xVBR21UQ0M0aNob0ay90aZPgEbRatvi4NZCcaPfENB1kmHuKya4L9XqMlTcQzlvp5o6OpSU5vGOW+11aXFWsDQchxETpKDsWpKSuNtMD4KT20sWxvHCZIXBOjjEVbrq6ebvQw3eiLwGcltuzHGC3HODHfkyQRVnxHyhzxbMA2NTneC9Al0WGkWJBtKTkGogxodQJJKTGNTEYQVzhOebEjFgv6o2vFirIuKBQPk6E+Sfzd3/1dCdtmhXf14InVsOrLCLP1zXD0cL30pS+9zFusUCg2g5FVrMbdcaqF++da6J5jasXJLr82H1pMt8KpzR0NO4aypeFRe0fwtGtHpfpHDy29n+NsTltOWbgQBuNvWcE83ezg+LyPE0s9HJ1r40wzQBSmsMV+QG8pRSsnpDmY74Wo9WIUHA3fPdHEoh/BZhpBEkuz2bVTFanY1soWunGGEwt9GIYvFc2uH0lsWJoA3zvVlibBKI2k8lopORiX3GBT8n6ZQnBqqS8e2eMLfRGJ+0YKCJN8dC/1NiuwbDLTNI6WtnF0riNZtUudQEYE09fMxr2CZcGPI7T68UpcmAycSDloIsLxxXwsMWPZ9o8WMVbyJGbMXZ4Ox9CHpZ6Pk7x/VrodA7qZC9VBsgUb3+gDZgX2gYWOjEOmj/eB+T5OLfZRcA0stNqYrNrSPEnhzHQKDsPg60dLSJ5usZz8YOpo9pliAXSiGI1ufjLIaDJWg8814EOhUFyBgvcLX/jCmu/ZbPaBD3xAvjaDwnY9r371q+VLoVAMB6z23T/bwRe/N4fbTy7guyc6K3Fjis15+rW78IRr6hgv5+NqxwougiSDY2gX5NmlWLx3tikikj5W5uveP9tAq5+IAGWDGiu6uqejSWFr5qkM9JHeO9sW4cuYrDCOcHqpL9PE2Cw30wnEW3y64aPumQijBEnMMbuaVFmrnoXFfgjbNNDs+jjT6ov1wTVt8Z/uqrto9xJpCts/aqOQGPCDGDPtEKMlpk5oy/7hGGXXzhvCLEO2lZFmTHto+ZFUQ7mNTIRgOAX/HFCgOvQjs+rsWuj2WcUGFjq+TEe7d6aDkYIlQx06HGntcDqbgaWOjxOLgQxCWeyE6Mca9lRTWIYHQ6e9IZZ0BQ4wYR4vK8NF28ZIIUPNs2T7ON64G9hS+WUGNPN0dSNAP6DPOResvB1PFgbNZnxN6DdmHBttF2XXwFIvRuAHSFITxYIhU9t4wqI8uwrFDhG8CoVi50EBdarRxW3HlnDbsVl8+4GO5PMqzs0jx4CXPOUQ9taKayKrrOVmpQvZ77efWsDf3HYaJ5bo0c1klC3TBbRMEzvDZMnJl98NC1ZBxyP3VEV0ua4OP8hQK9uSo6uzqlpx0J5NsBBT7BooWTrKnoHd9SImKjZavQRh34du6fATNn9lklqw0OK/pgyVYJVf12002hH05dQJ2h1okbh2TxU1Wiski5n+2hRxxOcZSgYtq5yMAZOIMCeSKmutZEt2r2Pq4vnVRZiyWptJZXR6eVw1n+vxpQ6iOEMYpghjD9d4JvbUbBRcE3NNX36v2e9LVZrjfW0jRTtKcNDJm+e+d6qFfhJB03Q8fn8dcUaLBlMUWEHmCYiBeqEM27DywR4RB2zwuXhoIkCUJBgvubCXkxUGrylPAGjbYO24FdBOkaBgW0jBYROp2DESRr5xVLTK3VUoHjJK8G437Gh41rPOXlYodhAUXZw29ZV75/Cle0/jLo4P3u6NukL4yafcgGsnKmuit+bbPhY6gXhlmTAgGbfLQw8GmbODqComARyd6eF0sy95yEfmm6g5FlzXQD+IkWqaVEnZOLa7VEAnicFAWlYpOdghzyhOkGmmpDAEcZ5pzGX3Zo8+U1MqpBS/9MD6SZDn0eoaap4jWciemQvU0bItucv7R1xpbOOYYTau0S/r+xnsKgdZuNhX88RSQHFYcm1Z5mez1+rhChT9zGrusjmt5WOy6ojFwbUsqcKOlFKcYWxaGstz4HWs7s43QrEalD0bkxUHB8fKGCu7Us2d7YRY4r5tx8iSDGGWgnPPRgs2Dk6U0PFD3Dvfhq3r4undV/ckOq9g2lL1Pd0IpFq+e7SAa8dLKyOLW10OytCxa8TBqOdKbBsrumkQr3lO/JevQ9FlFT5Gp5+IT7no6BLXxoZFSv9GLxBhzMQIhWLoMIZbzyjBO0wHiEJxhbHZiNPB9bQy0Ct658mGjFtlfu7ZMRKKzeCenGv4OLnYxd6RvMJLf+m9My3cM9OWFIKxErOKC/CMvPufS+L58INMRCkrqj3mYrLC3uyhYOrLYpcxXBlGCiYqMuihhPGKjf2WJUKQwx+SJBUvqU4bgmWiSjFme/La0Qd8x6kG5roBsjhDw9BwdLaDhS7nMSc4OFGGVdGxt5pPYWP6AEf3MiqMcV+sMp9s9tHuReJ7Ldm6VI/ZKMaGM8cz8sbGTiBV6XhZyK8+zih6mck7WsyTHPg4vI1jRVhoh4hTiKWBVoowCHG6GaJS1CUmdLxk4bpdFRwaK4JmgWY/liEnZ4JExDOby+itPTBeQs2lVcFCux/DY3RYmsHU6W+2ZUzwbLMvdguKUkbHBUEG3U7QCROxhYzWHNQcW3J3ObyDJxiel8e6DYZcyOCKKBZPML3PuqbDsTPUSg6iOJGmOPqUTzZ8sfBxP9GTzH2gUAwVxnDrGfWOUSgUD4nBiFN21POPdNHSpSGnGbCJiNFKwFwrwJfumsGtx+bQ7aVrInEVOGdT3r8cX8AjD9ZQdDnm10Q3inC63ccDC13MLPVxF5e+OX1L55hgE4/aX5NUhY4fYZHRYSUXaZxKNVL8oVomiQrT7T6CxITOzNdEw56ahwMTJezmNLCSK+KszzKrpiOiyOTojyBCwjKjnsKzLDg6MFZwcLLZw/G5NqIolcxkpkecavjYXfNyD+3y1Df+Kq9jvBkrn7srHhqWgZGCjVYQY6kdSVSYE+ajj9kcxuV8bjfzdReY8rDsnaV1gTAJYjCOVxrbdC2PGksSHF3IcMfp5nKDH5vfdMl1pj/2pr1VXDNRRtV1cKbTl6r5XDeU8c20LrgJ4JaXq1NMlkhp6chFZofT0Yo2sjSFo+nYVfVgQEc7zGPMLIu5vYl4mim6qWlHXKCfpJhr9dDqpzJmeKJSyEc+p6mIXZ4INMT7TAtJDMswxXPN4RkU9HwdwmVLBE84KJ4vzbgmhWLnogTvdsNPxLm5/PL4uHzAKhRXAlLBjVidSjHd6mKhG6DZCbHQi0ATZKLpuHuao4NbmG2lcE1V3b0YOv0eZlo+phu+CECmENiaLtfdM7uEIMqQasAovaPFgjRJMTGBjVKsFJ5K+zAz4LEHRqUyKRJO13Bsrotmz5fmN4rQetkS8dvmoIYwEpsEq5mTNReNTt4c1u1FsM1ExGTZoxCzEPQDdPt8XU2xM/R9Ti+LcN3umtwvxSPJPbd5lbZetmU4BP/TNVuEnKnnJ0ccOiFFT05JW/4dVkIpWrv9CDanmXXjvHEN2poTLUZ7UTgyV5eNcBz8wDzeiZKDVi/GI3ZbEinGFYc40dHsRrLdNMeOVTxUPQenmh0Z7lBzOSbYFLGeIkXJtkG3xzUTJVynVyRT+KQI9zzzd++IJz5oimJuN98HC3L/jDnLTwLz9AeenKSIY40zNtCP84l2HFyRV6fztApW1DlGmAJehlvEiSRnsDLe6IcYLTpyUqJQDB3ZcOsZJXi3mygCBlFrQziKT6HYDP4xZt7psbkO7j7TwB0nmmiFCXphiDAN0e7E6ISccJWXLDlBTQUzXBhl/r0YqUiEFxMHGL/FPx1jJUd8smy+YjpBp0vBm3txaTtghbDkclIXY+BCEbiMHRstGjg4VUbBsDBacdD0Q3i6JUv4x+e7aAaRNHY5Bv8khJBHyzKJPssSVvMzEWP1AsfmGkBmoen3YWipbEvRtHDDwSLqBQu7awUZr8sK5kaTwcjA7tIJEjglR3JsmTNMX6xMGuOIYj5nVnpD5uEm+cHDqWmcjBZT3AJNP0Ao6QY0ueqS3tD1QxGqHGnM6jgFIj3EtNZwPxXdEMcWEqlGU3n2eB9MZCh7MkI4iDiFDbB0VlW5SsGotdwzvdSN8gprwjzfTHy2HOk8WclTNMiojIZmVTZBkbFmjDvjyGLmTmuAoSdSDecTYAIF9zcr7xSxA5G72rfN3+X7TDd0TFUsjJccZWdQDCfRcOsZJXgVCsVD+/Bgc5SRYbEX4NhiX6Kq+mEoAwQyjeOBAb8vK9FgMY3ex0KwdojERnDId0nP7WDzjKa6yl4fSsKDUzZu3jMizU+c9uUlCYqeJTFf9SIHFzgy5csyM6lsVl0XuyouDoxX0AtCadJicgEnhvlphDAyJQqLphIKNjoWqtX8sZiq4LBiqCXo+rFUkzmcgRVHZsT2khhNCsmIXlxWXk0RZiXbRaXEJIVU/KwHx4qYqrkwDUMqkqxgmkbeRLd+Mhgvy8hfxm1FjAXLhexs18dcO4NH33DREaHMx6sxR5iNbIYpApKNXxS7nJzGIyTLNMn9pci9Z6Yj0+BcR8ejx4qSWRzFqZw8ULizGsvRxP00xmIzkCg0VoadahEjloV60ZA84DTTpDLr2AbiOEXJ02GZpohhrmIwRg2wZGTxwI8r444NXcYIr/YcVzmVzTNFkEvucJTAYcU6XK7oWhvn7Mr9ZpDmOg6qYBV8YBNRKBQXhxK8CoXiIWMbpiyfV1ihsjPMNUPoen6ir1tAoQh4OjA54qHsWZhe7OM7sxtPWJu0gL2jDmplF7urnnTyf/2eBZz2h/MFouzY+Jk8GNY5CjrQSM//gfyUA2U88eAYnnTNCK6bqmKx64v4oje3E8QYrXjiqQ2TFEUrQrlchBZn0uB27VRRluenmz7m2wHmer4IJKYyuPMmlvoB7p9rS0Xx0GgJj9lfQcXmwIkMo5aDiSqTHwwssXzKIq9GeaihXnTQXozEthC5sVSSZ5o+RgsmMm0QUcbfNWVbLUMXgca4rc0GJqxEbElDVyrbeMcDi5LPvL9exH45vvLf5/2W9Ty79uz9ZdLE5Vg2LPHYGji12BWxzm05tdTF/VZbxgDTplH1TBlkxEYwVsppJTi20JXmu8BPcbrRx6jHVIaCDN3gMAl+LXHWtcbUCEa4RTKgIgj74qOlcJUhwmmGdswTiXTleQ2SMyiEae+g35jbSGsKTxhkZPC6iLL1DH42GFQxGNesUCguHiV4FQrFQ4aVKfo1udTLCq6lWQizGJ1uIsKXXf+jZU8anCbqHuYXe0jT4zi5mKLNJAEKXQ/YO+Hi2npdVKTBZiTHRhwBBY9TK4bzBbpQsUtGuHpuAFE/r3BT3oxy2ZxKmP1hFjBVK6DuOXjadeO4cXcFu0cKInQoWClwuSLOSKyybYmo9cvAbKuJ0wtdSQ24c6aNsaqHimvmlUkOPmCmbJAhRirxXM1+CMfQZRIZG87sMzr2jhSwZ7QokWC8H8LKK++Dr0OSRpjr+JiqezKYwtC45K/h0HgZ/SASYSsJRBmX+jMRyc02RaK20oR2LtHLl7gXmjje7ksuLxvVmNs8XrZlOZ++gvX5s0wo4OW1yQ3M12Xzm41bj8zhgUYXR2ZbYul4xg3jMNhkxsa1giVZuPPdUJrC2t1QvMo8GeBzsY5ouGmyhmc9akpsD7RycDLbTIOxZX1pCOQktMMTFXgWq775CQPFrrdcteXoZj/OpJLMCi4FOQU6q+/cf4xQI5ulmwyu5/e0llD4D1I4FArFQ0MJXoVC8ZCh8Lh2vCLTuJYmK5isuphr+ZjvhKgVHBzeVYCeajg4XpIqnXvtGA5MlPEvx+alO57DAfbWC+gHCY7Mt3FspoMlP/9gYl7vxUaYjZhAGgONIXtNQ04AY8WUlV56dD1g/0QBJceRwQJTFQ+1koWD9TIesYsJApbsW4ofVg/ZdDYd+NIgGDLyisMiXKAYeehEfYkRMzVNqpFcaqfnlwMUdlUKmGt1wLOPjMpabLWspmaw9FjE2Wzbl6xbpjQQEZd2nhKQmWwu47Ue2j0KWx1VL8/pHWT9MheY1lz+jPqMwyZSh/5fayV+61x/aGTJ3zVRK1C0St0Wdc9FiV2O3G/LIvJC7ocZv7urXRHKhqnJWOP755oYrzqoODa0kYJk2HLb6ZmtFi2ZujbX7kmeLiexlWgd0dvYfcpBwbXR49hlQ8PhsSoWur5kD7MxLTy9hEMTJbR6jlSaDVOX7WRlnJV4pi6wokvfsGvqWOxGmGsHYvlgZTiIM7GZMHWC205Pc9OP14hkpkeI/cEy1HhhheJhogSvQqF4WHDE7SHbxO44wUTFkeoXp2QVXA0mTKkucjm36ORjZdlEdOPemjQpsTDICVj/86tHcNsJ/6KqputhbXJPzcQNe0aw1PPxjaMtLA5J6K8f5SJ3z6gh+6ZkWdhTKeDQZEWqiMyEnahy8EJhzcjgwQc0G6GWShZuuXdW4sravRDceZ6roS7DJ4BW18fxOQP1ki1jc/dUHXhu7jHl8A89NTBezPNjOeSAt+GIYYMT0Pw895ZijK8Rl9y59O45FgydFgETS24k1gOK6QGM6uKJDHNn6XMtFnM/KhUwxe5gyX6zvGYy+FmVJ0gTZcSxjsmKjfGSJz5gisjB/ayPxFttIRh4hXkMTlULQBNY7EWwTB2nZrsIR/IRwHyeTHqY5XjifoR6ycM1iYaFTgzPiBAHqTSYnV6KoBsxRksWTi1GIp554sG83LLroGjrSOK8es7nP2Gbud83SaXCy+P7VKOJeoG3NSTd4UzTR5KlUmW/DhXZZ7Q2kKYfiQ2F1Wd6p7lfKXZpJ1nqBiqKTKF4mCjBq1AoHjYDETNeduVr4DUcVChXd59T0F2zXL1s9Hx86e4Z3Pkwxe6kDTxiTxE/8Mi9uPlADbWii5OLPZm4de+ZJv7xjhM4cpnKvqzg8rlEq5rwqkVIZqsvU8QyXDNWxBMPj+LweEUybCcqnvhKNxsmwOtdw5BRt2x6KnoOOt0+Ritl+EaCdj8U28N0tyeiq+haqFHcFl2pXFYcE2caHfhZKpXY3fU8SWFmsYcI+ehfyzDQDULx1EpiAEVYn8kNBiydIjaPAXtgoYcW48FsPV9mN3URe2w8G9gX2Ky2OpVhI3G6WrjSPsHs5gOjZaliszkrty2kK8cQb8PLFNQ8nlZbCFZXf/fUPTzl2hHccdqCH4eYKpfAPi+OSD7d6spQCVaATyx05YvCfMyzcHi8zPY3+Z6rE1JVdXScbvqoWDyRcCSL2G90JU4siTSx7XD/1iUZg/m8ubWBgzPun2nDZ14u94muSVYvB3BwhDH3GT3ATNMg3H56iymGj873JF1iouiIlYJil9uiosgUioeHErzbDUszT3va2csKxRXI+oqbw1SGdZ35qxF/YhjjnukWvnzPDFoP47ErbPS6bhQ/9bRrcOOuqjT38P5Z5aOQeGB/Vcbazrfn0Ugu7r4p1y4mSo0yjgU7Dhvo+UAnAQoOsK/u4pH7xiXqaqzgYf8kM2KL0PQMlmfL6N5zLf/LYAWN/t18oth8q4uCa6IbhmiGEZIoQaqbiKIMJxsdOKaGfmhjbJeLm21DJqH5HHIQJvDDRBq0GB92w+4aOiHHCzsyLCFJdRh6BIvNXczCyjSpENNmEEUxWn6C2UYPqGbQfR2ViXwqm2auXXJf/dozR3YzcTrwvsqAiTCW2xacfBzx4H7ok5jvBTLQgtVxNpJNlR352UbVX57sPO1a+qBrubWgH4r/drRsiPgcr7q4d7qFmWYfi91QnttY1cXT9tZx466KVIArRUteS432At1FyXOWTwp0HFvqiB+aVpB9kSevy427alIlZ8IEC+C+n8qQDCNJ0A1jsYsUbE8GaHC1o+QaqLgGRopnn6t4gRMOB8lTLpb6kYxMrhddEflqsppi6DGGW88owbvd8KB4/vO3eysUiofF+qad8/kt59s9fPGeWfyfbx3DbafOF1R2bibqOp50eALXT5XFn7legC80QgRJCDoFGjQGXyD7yxxgYErTUicCgk5etaVLYvDvaii56IItOcChyQJHK0DPNBRtE4+YrMJmV76pS9XQ0kyUPFPyVQuOsWb5f/1SP6uGFG3MM75+F2PHIkyXbDT8SGLAejNdsRZwahersfSFWrqJk0sBasUOHrmvKkMXOHL46FxPfs54LtoOaKMIFzgAgZmxBmxHl2zYhW4faaKJlYFeVG4WM2kpftmESBsEr2NVmVVIphdwuZ/VW7K6uiuNVxo2FKerUwiqRVuW99c3ufG+OPlNJsW5llR6s4qL8nK6xEY2CYpefvGxW70QuyqeVG+ZqMBmPk46q7gdzHYD1BxXhOzUSEEsFffPt6WirWl5pZf2D06IW+pFuL/Vwn3TLTlpmG+xAZM9ZRmuHashSzXx+LJSbzOhROwg9CFz4IQuz437lvFmZdtZUxEn9G0HRQcPhJGM4abVhVnLfO2U2FVcERjDrWeU4FUoFA+bgejYSNSsp9H18X/vmcHHv3wEt5/hkICHTt0Evv+63XjGDWMicNYLcEZUfeF7s/jyXa2LriKfaQPtdoyMmmW5UluyIV7OTh/oZmuTGth37+pA2TFE0O4ZK+HRu2tSJeVYWC6jt/sJZpsBFtsBji10JH7r+j1luIzW0s8Kt7yBKZJl7sVOIJO9OEa4YOUjhGszXZxqBwhDDjNI4McBXNsRQVz1mOrAbNoMd51pihjmcv3hqYpk3cYZxwm7qHmGCLnpTg8c2bar6mLS9dD2Q8RRJhXeTpMT1DJZig/oPXYYq0XLQi6G2Zjmx4kIuUGFlhm5A5Gr5TGycjLAfN/1Ynb9UIqNUgh4PSe/LS5Hs7HCO9hX5/sDxtvQusETodX2mhoHetgaRk/longvxyvXPWkWo1UjjHjyxpxpHfOtPo4udHCcEWbtEPO9EM2OL1aDZpCIVeLwVBeew1HKhmwjM4RrBRe9MBaf8Hw3EFsD4+BqxcLKKsT6beV9FCwLRZc+4BBxlorIp8Fko99RKBQXjhK82w1zGpvN/LIkwQ/XKD6F4kK4EOFCKC5OLvXwz/fM4dh0yNyAh0xNB551Qx0//tT9ODhKY8NZBttw+8kW/v7bDzwkywTF7JJsdC7YegEwbgCVMpecE4R9SRQToVtkZbfMWDagVLAxWSnA0Qzp0ufQjayfotWMZcKWbWk40+hirmPJUjuFMIUqPaKD/cal9lPNHnr9EHfPdDDXCmRCWtnUYFFQFyyg08sbyyz6o4siAlmx3VMt4P6FnkwDcx1LEgXGyo7EmT3h8KhMRasVOUDBwH0zHYRxBi0FTjR6GCnbItT4fFmVPDofYabdl+apXbWCbMNIyRURvZIJG2grJzqD15iVfjZpUfEyQm31z9nQRc76fc8tXPlzDl6gpWDg4b3Yiuf6x+Bj32CbMqyDQzjYVDZoFuT+GxzHFPD3dFqS1zvf8bHY9lG2LNglDZmmYXeFTYYmopTeak2SLaSay9xgRp4FpiRZsAp+fLGDw+Pmslc3XwHhvuJj0GqyFERodjiWOMRSpycrBKapyShpFuQnlpsNlehVDC3ZcOsZJXi3Gyb0v+99QzuKT6G4UC6k4sbl6OlGH3OdUCqkD4cSu8N0G3PNAI2Kv6bCOxDgfT/BmS4eNoNNdWyO8vUQ9jsw+0DFBGyN6QsuDo6W0PDZ2AWYtAcYugyDcFm1cyxUHFZJs3w8bczhtxG6eob757qolyi8EokWoyA6tdSX5fH75noyQYzVwflmHxEtG90YrThCHBsolnXYPRvVkiVL8KzMcgmcI3KZzKBpuiyxd/oxRsc9qVpyShsFH8VWwWE1M4HGSWcBBymkIpyZT9sLGaulye3pKeW0MtsyxYO6WnStHxvMCi8FLj2srPAOxK5YM4IIjX4kfxhpYRhEcp0P3mZgV9kqeJ+jJe+cxzGbKo/Nd3BkuokuxyBbOuplG+NOATMdT5rXxisF2eesesfLNhBJagA90YmcPNAysrtaEFHME41BcsVSn1FoPcy3OR0vkFg3P8zjy3gyE8QcmMHmtQzdMJLhLeqPtmJoiYZbz6j3jkKhuKQMYppmO33MNSLcN8N6a4aSCbTifHTwRtp3IIM2szxEIXDnqTnQCMsq2dOuGV8b6UVBU3HEV9t5mM+B91qxgXLRhW0YqFdL8LxQ0hF21T3sq5WwZ6SMao8pB5lkrM72fFQiE6bPqK8YHgdCtJh5y9itgkRZ1Txb8ncpdlvMH+ZSeSfCTKsvIqlqMTHBkiXx0bIjtgNOUTNDA5UCpLnsul1l9PspPM/AockSxqoOri9UMFMrohVGIrg4dEHXM1myHwhTaeyreDg8EWOhHWJszJYpYlzyp4hl9ixtEUnKccSpxHPVKbg2WIpf/YdkvQAeXOa/HE/MKqhuaGIbSNxze723myjRZMzwofGSnLxMlT084dox3DRZRZAl4g+n73my7Ionl0ctLQ1F3ZJ9l/uIM2k8040stytY+cAMvi94AtgPIVm9zX4sJx/M4WVD4uHxEhaaAdp+ILcfL9kYLSRq2ppC8RAZ5s8ahUJxhbE+b5Ve1FONHu6abuHbxxZwptGTRqGuH+PAqIGlfiLL1awg9sMM3X4oKQeTIyVcT1ERRfjqvbOYbeeDKFYzGwL9xRSFQge33DuPg2NFPGKV4CUHx5h1a+D2mYszT1C67Cuxc14KqnCXrQo3jJfQ6MUo2ByW4MmgiEftr0vDUasXIeaIZR3QdFYx6YbQ0OwGOLIQIAxipJqGg7UixioF3DxVwUjFleQGeni56bQCzKYB9o4UcWqph7GKBRsmWlEIAxzhbMpy+almIJVYCtbdIy60TEeWUfSaiIIEC70IRVeHrpn50IksQdXNc5BXC1aeIDxiooylMoVxhqI0Si37YyVtg2LdEu/vZlaC9a/5egE8uMxUjiBIMNeNYOtAcax4Tq/3MEC7CPOAZ9shDk/UsH+0IEkg+0dKedLI+NnGQmYGB1GMetGWBsBoubpNP69n6nIiMbhdvx9JugXtDq1+KBYRW89QrjjSEMe4s1Y/lpHEcZwhMTM5ESq6zErmgA71p1uhuFjUu0ahUGwJg2QELvNSIDHSqdFPcHS2jW+fWMJ3TjUR8I98P0TBs7GrXMaNJRs376th90hRBFezG0mjznjJlQls7Ky/brIuopdL/P0wxJnFhH1gaKVAOwOOz/TR68/IiGMuGw+qvCeX2rjl3gVMX6TYJTUAu2oOIgrFxJQO/o7PBqREPJWs0tarRRkvS6HNCigndH3neAMNifdKkCaZjFnm/uh08ufF5ekl5raWPRmQsG+0IB5fR7cQIRURVOaEMQDXTpQxWrRkCZzL2bZhoh/nU7uu6SWIWEH0LDlhoAhilZuNVJqtwe9xqIeOXkxPaYIsO5uDvB7ur8FUt/W3kSlo7NY7z2s+aFLbKGVhAO+fgp/PiVnERXP4m7BYoX3CobqMfU7AKreDyVK+v8lqcc/MYE6ZWz0WeP0+5UoHrSJM02j2IxG3POExDAPVgi1+YtfMR2szck7XDTnW6aHWdKabBOILn1w+sVAoFBeOErwKhWJL4B93ijtOObv7VAe9IESYaVhq+7jjxAJOznWl6jVZ88S7eeOeGh63t4ab9jJZ4GzD1nqh8K9vNnDTnirunW3iO0cX4EfzmG/lzWJsf+qEQLIQ4R/vOI1rpkr4/kdMYb7Tw1/eegIfv+Uo5h7Cc2E1+chsIHYKPY2lKjdStjDbZqYskBnA6WYP5aKF4EQEyzBRdA1Q6YdpjKplwqNYtXSEcYq746Y8914Yomg5ODReQDtIMdMK4VgaRksaXNNEpWBJggAboljBpRDNxWTu+ay4zvK0urNWgcF+42U2R1FEMckgSGJ4qQbXspCyqUqW3B+6/3qz15zbxVgvjooO6Ve2rQdVklceh9tL28RydN0gt3mYGSsXpJHvfA2ZD6psr/teTg78SCq6ScymN2YOm8jgYqHTlyEgrYgZy31MVgty0shmxnY/guHmxxHj4Dr9UE50hn2/KRTDhhK8CoViS+By7Ww7kPG3x+Y6MtbVNTiZawGzrQx+DGQx+xoC7KnU8X3XjOCmqeoa3+1GQmEgOKpFU0RziTmx7VAagklAUZoBM60ubju2hH21Iu5faOOrR+YxexG5u6vxeZ9hnrVbd/IRuhS1oRHByzQs9mLYZopGN5Al56KTot3LcKrZlXQCQzPETsHBDmGa4tBkGSnTHvQYlYIrDWCpybGx+ajbCVbylp87G87W7w+mP4RcOqf43USgSjXW5WmAJj7QqmlLsgFj1Gzr7ICDrWQgALsBnxwzh61NB2jw8dmoRt8qK5qsSDPhYTNxPEw81BOC1fD5doJEjiN6tou2DT9OESWJvE6tKJNqLhvYCq4lDWzMPd4zWsQ4T6wSWl5kHMYWPSuF4upCCV6F4jKyepjAwNO3euzulcig+eb++Q6++cAi7jjewFw/xFyjgyDK0OtTrFHs5bnkmWZgoedLgD+rmLuqFLT5svpmcN/wP3pTm34o/lhpxmKVcbki6/vAsZkOPv3d0zgx35bRrg+HwTgMxpG5hobD9TLaEWO6eiiwwmZCsnKZuBAHJoolE+1+LM1H1aKOVpBHVd28d0QqoL2QzXVU/RzZSz8mh3RQ7FD8xdAta2U07eqmL+7bk40+ljoBdDbiFSzUS3luL4XjoBJM8nG8+oZNY5fi+BqkYbDBzQnzARKb5TDzelb2Oe2MS/s8cbmQISU7Cj5XU4dnMSHClnzddmhJ1vJE2Zb4OR4X9YIj1obJiof9I/n7g1PjgiQRO8SlOHlRKHY6V83nzNDC7oQnPensZcWOYr14od+RTUwcS8oxorya3ftapqFeNKVB5kpoSGEzGhtuWJ3iMi2jtW49soiZVg/T7Y5M52I8lR8BUQrpdI8SwLK5rA2JYPrKkVl873QLj9hVxuMPjODweGXT587Ha/k+Mo62Wk51WD30gTRD4Nj8ErpRIHYB5zxvJ9aVixwDmz64IW4Ak8921y3sH61g14iHydTFvhFPxAcjqJb6fZiaia4forkYwWEFzs9f57qdiK+XVc2RgiM+XMaNNXsRDowXpbGJHlE2lLX9BB0/lOdncDatDIhIEUWp3P74UlesAnNLHRwVL7AtIpOZuPR+cnDCYN9t1jR2qVjd4HYhy/4MAuNUtgsZUrKTGFS4mU5RLJooOrktgbYGWhQKloaFToxH9AMULVPGDh8YKa0MnFh9InOlnhwrdjj6cOuZ4f/LutNhmeiFL9zurVBcAijSGPrPZUku9XLSFIXRsfk2vn50Cd1eKI1HzDVlpYfd3Y/ZX8Oj99QetMw/TOI9ihLcO9fC0fkOur0EOlLMdGJ8b6aBNseiLjJDFGDcKm2jlKjUYkWLXe9AkGToNLvi7bWdnsSVtXxmnBqYLHuIGFulYUUQ8HFPL/XwneMtnOr00WgBG0Xr0n4w30zQ6LRFzZ5PR40UAMcCtDYF2IMFNKk5wMGJsgx0YOWNmba5WIsQxhq+dybFbMuXmC0LzN41sHdEp1qV7nymEjB5omib4tGlzaEX0POqSSICu/dnWxEeWOhJuoNBEexaYqFgXjFFIcfcdvoJ+kGMBxY6MJe/5ySux+wfEc8uG90GomjYl/0vdEjJTmNQ4WYU2+rnPXjdDoxVsHc0f3+t9nCv/n31B1sx1JjDrWfU+0ehuARQpMm0rAY7+jX0oxS7DQbVpzgy08ZMoycTleI077Yvm6ZUffwkQcWzcP3UcPkaB934nSDEsdkObnugicVOTyq1zGalt5Td59NLPdBxUC8Cpg04moVqmYLMlbgxx9DR7CdoJjHme5zRy5gqHwu9EK1+gINjJdSKjkRo7aq7IoDpffzOqQZuPTqHo9MdbGZUoLVhJgKKFNo+5PH0c+T4tnpAvQQwuYuZvhtR8DjWVsdE1RPhaZk6araFMOMAADYQBQhTeis1yVzfXXWQcaREnKFccGDZBiJpHDNluZ9e5NGiJjaFfOxsgtMNX+LaWDV2DE2movWDFO0whqExicFG0WYerCUnRUmqYa7Zh5+lYguply2pBrJ7/0rww17N4u1cz3vwM2VXUCgu0ftP7dhthp03vWW3YKEwdKP4rkY2ihO62N/jv/0kho4MPpfyDUYPcYKVJhO4dIMZnREMncv+CXq9GGNw0CuEaHRDEXnDJFz4fCh2Ty908Y0HFnHkTBtJmmKBU7/6+XCDVtcHe5eSGAhSoGjq2DNSlApwwXFgahniVEMn6MLzbFnCZ8YtLQBL7QBfv28J3z3Rwk17Krh2qiK2BdoiGr0+vnVsEfeeWcLiBTSh8S5ZIA/CzcUu4bsu6mxc2SVs/3I9U/Jn5zjeNc0w3dBQq3ioOSYcx8RIxUE/yjDT6WG86ODQRAlJlqIT8CuSKWWS5bscRSUnDiGHb3RwsuHLqp/vR1joROJz7qcpygVb4thkulo7EOG8q+zKSsB41caRmSbS1JIKeJjwtdFl+ZAnDLQ58DFYJV9fIVQoFIqrWc+oT8PthmWh3/mdoR3FN6zi8lJuzyBXdLD0un67Ntrmwe8xeJ7RUKzUseRI/6qOBKVCPs616jrYO1bEYjeSKh67tTUjgplqCJMElm3mHs4haELjcxwMG+gHEU4v9sVWwLwkbuPRmRZ6fgiTplyG42u5SNRtIPSB0aIuAqzoOThcr+LYYgshEpkWNt/to+fk6QqcNNXl0r0RIkp13HmmJfuV06uOz3ckkYG5rY7tQpP8hLMfXiNWLliXorPXUfC2w82F7GrOdZuaDewqlzBSdjHd7stydMOnoOyjtKuEfjdEuxsgiWOUHBN76oX89dY17BspYLEXSC5twbbhGQZ6USze7Qdm27h/vosUrB4zjzWQcbvcV5WijWYQwfcTLHV8sXn4QYj6ropU/s2ehusmKjjt+Zht9MRHzAo7m55QsrDIinOQSlMc/9bQb8yUC4VCobja9YwSvIqhFpeXQ1Cvr8zye0682qiDfLNt5u0odukFZeWS1Td26O+r50vyI8s5s2xA2VPj5CZfpijdP9NCocDu/gS7izbYtx34CSJGNtFgehnhc5LhBZ0AM+1QKrhspoGR4Z5TLRxf7GOm7aNgGmj7IfwwRKcPpFoGNo1PViykWiRCv1y0US25GC8XEGUpFgMffpqCbuXM1HDTxAjKTg+nltoyUEFjcoWuS0yXR3uHbaIbxXBME45Fn7Mtof8c+hBGAGchjHiA57g43fRhsTluuSpbtoB2dO7q7rngfYx5QNHTEXEYhs8BAREW4kw8EqFtI53uoFZypErLCKnAT+Xy9bscJAknsRmoeyVpUqKVIUxSnFj0Mdft4f7pLjItQxBmmPG70E1NqrmSshanmCx5OBP2YJrckgxL3ViGXvA29D/32MjW9GHoBirl/ISExyuzjBkPRptJL0ww1+5LYyG9w8PoCVcoFIrLiRK8im3jXOJyIL5WAvUfQnTXenE6GO95rsosO+f5s806yDfb5kHoP8VuybUQ0ZubpJKzyaVl/s5gO+gDTeMUvX4IrkZzrGzN1dBmxTBKcGShLWKKvs/LtSTNbVvqU8AyAquHvh/DtgzMdnycWejge9MdOIzPYuXX0VEtWRiPSvDjDvrB2abcqXpRBLtlmdKwNdvuYqTo4uh0E7ptYF+tjCCMcHC8gNGKJwKXVW82bGW6JjFd41UP+0Y98a6K4NU1POGQIxO6rpsq4VSjiyDUUC8Y6PgRen4ugikYyxwKlgHdTUq3rAjHyz/rLF+Xy8o84oxDzvh9kYLXtlAwNWlSq3l8PXSkmo69dVcSEyipmaTQaFPIchsKGK/1UbZtlJy88YzpCyz2UzAv9nx5bDYxcuKcnmZwLAuanmGhF2DUc+C5lowP9sscHJFIJisFrH7/HA5NVGXl4O7ZFh6Ya2O87ME0HBRtNstBrDAGj+s0E7HLqXOsjFMkly7LUaRQKBTDixK8im1jIDzXi8uB+Gp2QyRZHmPFDnnHMi+qCjwQp7zb6WZfhGdp3f2sr8yi6KBo6fk0KP4sTuRr0EgyGKG6fptXh/5HSSyRY9K45JnSsDbfDSWJQNMSfO9MBw/M99GNE1w/VhVRSdF0qt3DTK8HXR/FiUYH+0cLl0Xw8jlxShYnh2WphrtONzDTDOR5e6aGlh+i0Q/Ra1KohRgvFmCbGVzdQN01UXJ0WTofLRcwUrARpAkyjv3thZJZ+83j0wj7gOsA/b0xbpiowXMs7B9zMFV1YOsGdo94qJRMzCwF8BxDAvZ54sAkfrPmgrMYdtU8PDDfwZ6qi47PkP4Ud55cQmZYsK1IVtM0Q4POav2658j65oQHTI1ako87PZeikjsxUHGZp5tHk3E4RNmkQIVYCPiaeVYEw7ExXnbFrrB7pAROBeAJyVInkm3iz+jHHitQDBvi187YvpamqJZsNDqRCOgsjeSY2GVbSLMMxxt9NDuxjP4tehbGizYyPcNkiRm1EU43+zKUoNGPxeKw1Itw70xbVg84sWtvjWNumeObouIZ8CwNpXEPqcYYuAy1gpXbaxQKheIqRwlexWVntYVgo3gifs+sSga0p1GKXpRIxXPwexdy0A4qqn4SY3rRFz+lrmk4PF6Wn1OUULQM7pNLxhRYYRLDjxkNxCYtNmRRdGvYU7VQpxdyeeABI8YogleL74E4PdWKcGaxB5+iqGNAMzJo4GjQBM1egG+daMiS8/RSn+PJoGk6zrR7WGwGiJBC1wxcM1FENhgldhnE7n3zXcw0+zI1bGYpXwq/b74NLckkZ5f2BYpA14VUcEuei9GShevLrDo6GC9ZuG5XBX6aSQxXLwRqRRv3nGH8Wp6gEPlAGkKeX9lzpIL8qP11GepA/6+j6Tg4aULPdNiWjrJtrhnOwaV5DlyYbxcl5/efj8wjynTpk2AaDkU2o77SJIbrJjKIguELzH3dN2KI4KwXXAR+B56XwmE6QwZ5nFiPofcBcRHwGIyBTq+LNHEwVfKwt1pAlqUoOY5YOqplVqdNsZ6wijtWstGJkjxejkMhDA0lx4Yf9rHYiaTKO1G2xCJSsnXYtonTS10RpBSvWRzLcIGp0SKiIIFpG5goOWjVXKSpJpPZ+FrpWrosxEMkGq0KDroMO6bVou1j/1gBk+UCqg4rxJmIXWVnUCgUCiV4FZeZjTywq2N4BkKVKQZxyF51RlnlVgEKlgsJqV/9GIl4OTOZWLTU9THX9qFljoiMrh9LTFgvCmHpptgQKIrnGj76cYY7zyyh2aN3UseZqo3H7dOxf6y0Ut3dqNIs4rkXiZCi55LNTn0/Qj/JMFFxMd+MEEaZxGVxOZz+VVPn0jhE9FEyuYYhwogNS5caSZOIE2mYmqq5EjnGPdzoB5hv95Gyos0TEoNZCzyBAPpJJBFkdXcE5bInvzdR8XBgoiw5tH4Qw7KYL9vHV+85AzphKTz5bGolE5MVG+MlG0XPQMHScWy+hxNLXdi6hmsnSjg8UVmTwduOk5XjZbTgiJ2g6Po4OFbEmWYH3chD1koxWjPhWhZ0w4FnRzCX+jLsIj9k6DPWcGKxC2N5EAYb5lg15vW0YMxqvhwvPOg6PuTEZ9IIkBl5LjA910zYoFBPkWCxm4jA53OgJ/fQaAHjZUdEL0/Y+jqPEw1JnIqXN8ssmTI2WXfRC5hfrMOPW1Ld5dhgTUvR7rJSnWCqYEkW6/6Rstgh+HMKZbHImHn1e3fRgcyo0IBMmvpMaYLjfqLIVTYGhUKhOIuq8CouC4NK6kDQbubbHfhp0zQTfyezT7txjDTJ/7BfCKt9toyDMjJNhgNQsDlIcarZQ9IAZpd6iDVIYsJkycV1kyUZLECfpmUm6PdSZLQlVCyEYUpr5AVNh2JlmhFcJ5b64jGlFZmi+8RCD0VHQ8nWMN1KcHi8hLJnodEN5P4ocEc8W6YrUUQO9smlTK/g41Ik6ZouFo7rd9XEEnC80YWVAYvL4rxiZUhoD2UxUQdMx0CipVho9/HovVWUHQ5MsFHxaBXx5H5rnomnXbcLnf5JtIIQY2UX107UcO14GfVy7j1d6ka4b66NMGb1UsdMh/7e3CKy/rXkvtfsPGu2YBehHwa6cYjR2R4WKqaMAK54NgqeDs/Q8S27gXYvQBREYh+gLSNLE/gZxPNKkf74A2Mo2jYeWGphou3JlLYgCLEkVgYLcZSi7tHKwIY6W66jWSFJDHSjULbluj01OTEYZYNanODYQhcl28DuuiteXTYkLnVDHBgrSB5xGRaSQibpCjyZONHoYY5e4FYox0DMqvo0rQ82ygVLhkpw21u9EHMdXwQ0xwtP1Fx04gTdKJXVgP2OIcfopT5mFAqF4kpECd7thurhcY87e3kHsrriKjJxAw8sWe2n5ThVipeqSw+vDq+wcWrCRgzsEawKh2ECP6GXkhU+LpdrOL7YFR/vySUfpq1LRZbNSXNtG5M1V8TEUi/D4ckiplsBtCzFntESpqq2CNRzNc+xWs04LVPLu+5bgY2eH2G26WN33cNoyZUmrl29QJboaZlIbRPXT5URxfly+JMPj2Gk4IrtgTm0l3KYAO+XQpQ+0UEMWdHVcGS2g1YvQqL1kaYJbNPERE2D76eI40SasiaKrlQc75/r4ZqJAnpxDDcx0IsjpEkGQ9fx/EdOYqruYrYZYKziYm/Vw+HJAsZKBZlEN58GKNkmTnZ7Imo9I3/91r+Wq48X2RdJioJl4prRMiqOg06/hEYvlBMFVuUtW8d1YYpWzxf/Nod8sDLMfFzDoO/YkqV/Tio7PFHEycWK5An3whTfO7mIb59qSGW4yAbEOEIn0FH0DXldTd1B1TMQNnWcbNOWkoh4pi3mnpkm+nEKEwaW+BpbhuT18r4npKNuWcwnqYhb5uou9vuY4fGi65hrhCjRw1yw0A8SGUncT2OEUSzPwwDHEZuINV1ynp3MxOGJEpr9ULaBx9yF2n4UCoXiatIz6nNxu6H58Md+DDuZ9VU6ZpOuES/LDJIO6HOl2KAY1HX6EI0LqqwOWIkL0znkIEaBqQKFoiyxL8h9aiImCy7vT8esn6Btp+iGoSxdM0+Vk7W4vM7fZ/NP2c19p+dLiuDP6MWkx7fgGZhe7KO57Md0XUvybfeMFjFRcsWXemKpg2LBhtNlWoGBx+ytY99IEWGaynbyBIB+40v5RuU2VwpnY6smSh4OTZZk5K9rG7I8P1p2JEc2coHdnLebaaiWHEwaJkarNgzdhB+k0IrAUou+Z1boaS2w8JTDY2gFMdKYy+4GHIPNW5nsV4snCBVHGraqjoEDoyWJblv/Wg583oTNdLJigEwGW4wWPcz1AxSbfQRRKg10MrhhqoJvHo8RpKlk4RoGUCl6si/HSwXUypZU9HlitbvG7FyeJEXYP+7K8IdOP4LnmLJveALmjhlwOWyC8XEWoBsZxjwb7TCU4yjOKEoDNHuhjBoOIhcHJ0pI+4mcyHCFgt5oK0lFFPM50Lqxu1bCUi8Rj3CrF2Ok7EjCByvgTF6gD73pUyBb0pTHRIuxgi2eaZ5IsSLM6nNu27iw94hCoVBcbXpGCV7FJWd9lW51s9f6nFwmHYRxJmK3WrCl2YficSOBfC4khgyQ6iErfnzssZKLKEkQFxwRntfuKkpXfrVgYapaEJEinlqD8WUZDIvVNHelQj2YKLZRw9r6xx5sL/24WsbRsrqInemmj4JjIHbY/ZahE9pY6sWSPDA14mLvaEH8xUyoYNSW5+gSz3U5YeWRVWpaHU51uzBME2mWYrJcRBD6EhXGymfR4X7Q4YcJ9tVpi4A0uNHvWzB1LLZ9WdJn9diEBts1pMIdLU8CYzVysuLCtTWp1vJ2g/26/rgw160U8IUwwLi3DEEaw9U17B8vSYYwq6JMSZis0HLho8Fc4U4fYaThcXuq8tjcDiYr0A/L14XHGoWqRa9yHzg8Ucb0YgctP0VP7A2GWFJ211zMF2xpFDu+1EMSZUj1DDqfbzOQ3+e46LrrQVs+DuoFZuTasr08mWMLo8aRwQVXjsv99YL4xOmbZroHfb+0JrT7sfjK2WhXsBNpeuSxUOUqA+ORYeDASAH1kiOvFT3GwzLARaFQKIYNJXi3G7aYM0+JWNbQjeLbCtZX6dZn4PpRLP7Nqpvnzo6XANvUxJdI68G5xOXFLNczloxL8PT1UmBQXPN6ei/Z0c7KM2+zvqluUKGmmJnvMK6Lo3LXWg3WC7R4uYpHZcapZHxe/GIFm/mqbDLqciiAYTAJTeK82NTGZWw/jiTuilO3KIB4v5cabm9XvK6soEY40+zj/qUOmn4AU4tkkMQ+y8ToaF0q3XlcBauNWi4+DUMmrrEqWXZ0RGkqopizhvkaMAnCNg0Ru5JFzGxiQ5fvK66zkpE82BbaE7ifWN1nxXwQIbd6pYAnHkx/YE5u1w8kQs2zzOWmLlOEOJvn2CQYhRmCLJSTnwPjJWk+pIA8tdRDu29hz2gBY2UOjWB2cF8GONhskkxCjBQNpKmOStFEpcjbZJhp9BGGMaZbvmxjuxNJ4yG9u6NlT7y8uypFTNU8HGC8nGnK/oWmixdXRLweynFIcb676mJP3RN/8FI/kslpbFxkDBkr/DwJGStacoywKqzGBysUiqEjG249owTvdsOD47d/e2hH8W0VgyrdaihgKHa5DN32A8SJjUkjF4cDgfNwK1brl+vNMBbxQME1iBGjoGbVj9dRdPW5lL2qqW6wDRTKfEMXHVOE2sAruVHyxEYDKvg4LoWdpiHignyY4JrJKs40etKgRA050wml4Y2jZpk9zPiqyzFGeK4XYLHFimwmYus7p1potAP4QYbMTBDHMXpRhGJiIuz5UlGkQKRlgYMSZBk+ppFAlzG73I9lO8GcrmGpG4hNgU1aq0UtxyrzOVtc6l9e4pcSepphsZs3cDGLdn2F/2xKhgZdS2Q/sZK7yFG8piE2FMfUUGZl1XVgyMAIwDMthBowVnEwUXZxdK4t98M4tomKg9GRktglKLApNBmHt7viSSJCwaZlQZPBG21J1MjQ8zOZsLaUROJn1lkd1jQcGCtKE95ErYiKY0n1mo/TCzWpgLOanLGBktsaRZhrx7JfxoqO7Dsv4nHDfLQEUxUXhqXBM3IrxeCY5f3lbY0KhUIxJETDrWeU4FVsGxQwzE6dbbOBK6+s1uJkxRKw1QfnoOoqYkseIxeoUn1ddZuNmqQoYhndZZv5BLXVXsmNxO1GzVZs0prrhgiY16oxmTfPuGWuKq0LtAqwuSvSGZuVD64YL+X2iUvBoJLK/X9yoYtOGIs/9HtnmphpdPKTdQ0YcRiRZsI0DUy3+pJ6cf3uEmoFB7urHixbQz9I5cSC1geKN24zvzhVrG/mAxG4n/l4tB1MN3uIoYNBBWNlTxIiGKvV6gWwLVPG+ZYzHiNnq9uD1yGvRGdy7HBlgLFd9PKy+k4P7miZaQkpHM3AoYkSpo5baPXpwbakkkqPNK0YvM03jy7I49Gzva8eyzbuqxeQLJ8A1Qu2nOBQsHNL8jQJziehF9mXSnfbjxFrGaZK/HBPUHEtyeHl6xfEsVgmDGni02Qb+PucrsfXv9GOpNLP6L2upYvIpyVkd82TE6yybYnvWVkVFAqF4uGhBK9i26CAoXBgjik7+ldpm8s+yvh89ouBCKeIW/+zzZIEBvfDBi3Ju40SEbucJDbfCjBRtVHzXBF7zO1ltZvVRS61j41XRDRRIF0qT6akYiRM/k3RCSPceaqJph9ivtWX6W/0j1LQ7h/3sL9elcziAuO8qi4swxAP7N6RgtxX04xF7HL6GJ8vK6XMk53vRlJBpmBMeXLT8jHTCnBkro3RooOOoYlnmwKTU/UoIA+NlWSf9KNYGspWN2Hx9VvsRbIfKQ7rnikNW7S/BJGBVj/A9FJPcm97cSI/e8yBURQLrpywPHZfDddNlXFGhn5kmG4HuH7SxmIvFOHJ/FpaMJi3y2orBS4vO46OVieUKm/NZU5yQfJ22Xg3QptMFItXt+IVUCtamG4E8lrmA0dSjMjktBgF8YfnVhDuI5+T/IIEPaRSwV1t9aBVgnYHJXYVCoXi4aMEr2JbkWV+25AKIaucl7LDfLNRxus5V3V5s59RTOng/Z+9z0H8FAcndIIQQZCi1Y9x29EFqXzemFQwvs+Da+eeTHo1OfWLuaoD8bh+KMdW2DxW7w9JwIgyLHRC+FGCE4s+ppdaDA4WmDt73XgdN+ypotOLcXKpI9XefbUidlWdNUvsA3E/qKJ3gghzLV+W8GmT4ByNdhCiE4Yyeo1NYvz93VVLKroUmKw03xO1USlYOERPq07b69l9SusJxS4TIGiVMEoORl0DzX4gKwSMFaMXm4/PJkNWgjnG+PsfMS5JEbvrBfTDVER3i7m+WYpTS13JumUiBkWo7BembLCqbzGGLZOqNkV02clHApelaY+VX0OsDH2fnmImgwAtn7YZnszRn7s8jMTP/bpMjOBzp6hlExurwfQb8zEokHM7TyrbQUvF5YimUygUiqsBJXgV2wrFDIVOvWhIo89qcfNwWS0QieTM0kO7wRLxQxWTq4dl9COKVB2udVagiNgJQum4Z+PWA/M93DXdQNGyRNCM11wcGq2sCOn8BODB28LHoQ2gGybSGMZUiYcrgAYRarRasMrOfF02fllMqrA1qboWXEMqzeNFF64RYaTE8bw29o2wknnWRTrY/kFkGMVf2w+lCW6+4+cVWd6AwrFgi0BkMyEr2Latw010TDe6WOj4OLGUYrxoSuPivnpxzYkJK6Cs7HJfsomQleB8P7AqmuHAaBEPzHekcc0y8qa0ZpejfSk6IxyJEqRahjROEAYJaCPm8+SkNEaC6XpfJqCFaSKRYN0owu5qQfaBZVrSgzGwa8jJiJ5PVWPn4eBcZ7GfN0XSS0x/M60TpOryeMDKCoPNBreSs9Kcx2a0wb6URsUwOedqhEKhUCguHPUZqthW8gljpogk/rtVFd71EVa0S2SrM3rXid31TWcXKiZXEhxMA41eJPFT/J7Cb1DxRKaj2Y+kKtjncAbTkglajLsKg+yCqsiMabv7TAdxlsDUDBGLI6WH37YksVklB/vGSphu+Ghw6lzNQxhFME0b14yXJQ+YS+8jJTZ7ObIfWTU9XxWdGbYFK8Cx+T6afixNcQXPRtEyxEfLBIPTjZ5UvlkNZcLCYHTuQjfGbIvNbpYs67OymsfFaWJjYMYyo71oBZFjh7fhRLJeKMKxaHMbGD/myOS7xXaImXaEopXIWF/+nLFhtZIjWc88AWGVmVnpnLwXxhFsm0NDUrScWHy9g2a81Scidc9G4p6tbDd6ASxdx96Jgvixe6zWQxchn1TyFIfV8XwbWWTW70eVratQKBQPHyV4FdvKZp7ZrfTrcumcirfqORtWy2T5OIhX0hf4Pb/I+SLRBtvMCi8rj2xSouBh9ZYVOskDtoCKy2arBLtHPEmlYNXv4LiH0fLGwnF9xbkdRFjs+uJpZV4rxRkvb5W1Ybzk4vCusiQYRBxVCzbNpRituCLid9cZHWatnDScyw4yeD2DMIFj2yi4IUJ6dBOg1Q0RcZxaZuHofAcnFzrwHI4kNiTyi4kIrAZ3klSa0b53qoGZooOpWgEVx5DBC9wIWkfKbv568rViBi0zaUeKzrL3lz7aHroBoCWMS2NMWQeGaaMZhBivFFEITfiRL5FjtBwEsY2j8wFYsO3yNmVN8nolOcFm5d0858kJrQg0oPAcq89KvGvKpD8eE9yjrDB7to7y+hzn5dea/672jF+K94XioTN4Tw48+eShRiYqFIrLjxK82w1LSjfddPbyVcilSGRYXSGzrbwhbqNqmSQ3hIk0lPHnRY9L8amI5CTTMFKwpInpXEMmaJMwdQslOxPhJVFfy8vRXNbXNS7jWyJQD48X8MhdVcmGHS3xvvOmr9Wsrzjz/mOKdPGHhhLjFS7fZiu8nRIh5hq4aaoqKQyTlYIMzEniTLzGMpijkm/nhQow2QccE804Mz8SS0c3ZHXbQL1iY77ryySzpX6CSV3DfJxgb62Ex+6vSTWWv8uK/9LyoIYzSz30izZqBQvtXoxiwZD7pbhcNABb40ziDEaaD22gsPZsG5qWyH5yjdyPHAWZDMXgyUeUxuK/pSWhE/IEhxP5DLQ5aMKkRYFVWKBWtC8oKWMQgWczASLNxG5BW8NMi0NE8sozxdKgAXKj13r163kp3heKh8bqzHBmNCfLqRv0dbPKr0SvQoGh1zPq83S7obL4iZ/Y7q24otnIf7vRSNqNxJpUbAAZMcsYKA6CaPkR5yUgTmMs9nDOpITVUWcScaZx0IQhjUYU0IzN4shYTtViFdHQDUyUrU2nzRGKb/5h5RJ/nv1La4CJ6/dUML0UouhxEpq3Jgv44cDHLbqM1Aqxq1qQ5sGSY68Mg1izXy/gtZDmsSCP4xqruFLdvWbCFJHLqIYZ8fQyhYF5u77sH7FKZCnGy46MGvbDFHMdH37IoQ/02EIEMqulnSCBFxnyPRvEOMhhql6ArQPVooPRgiOPyYIs76/dj2RUMyvwZxpdSU1gFXex28NClxXYEK0uM3w1XDdRlUYyngDIVLNC/lqtr8Cei9Uxd7zMlIeZNsSjbhp5isXFJIcotp/B68TowPlWCMfWxCrDkyVaWviadfqheOzp996q1ReF4orCHG49oz5bFVc0F1Ih22gK2uD7wXUUjwXbEpHHbFyKUwpODoE4F5sNmFgdSUZBfHqxI0kI7GyquRZqJRt1187jysJERDflLoVdwuoohVw/lkYoEcIykEFHtWihYDJZIa9W87G3YjgHt5cpEdze9SL3YhgME6EPl/uQzg7aAlhi1w0Hc+1A7rfV8SXBgBaG8aqLiWpBcng5CY16sODomKwVMOI5kq5AewPFba8douq56PsJjs13xHZx33xHqm70IjO3dpYNbfT4eraIXaYgTDf6yycUKWzLkGl2FM4LnQ7m2zE65RT1uT6u21XFIyZLktAwqOo+VH/3YN8WPQs1Cm7TFMG+ujFTeXWvDAavk5yIOrpUeOM4RbFoSvweT5fvoxkAADkMSURBVNyOz3XFq05v+f6RIvbUChJzp1AohgMleBVXNOerkG1kD1hdkaWAWV8J5jhaekDZW88l6nMtZ28mWFYvR3eCHo4tdnF6yZdhAwcnyiJqmVBFpUtvJ/NiuYxv6oakGFDAMSe2VnREjKccMYxEqo4cfytNWxm2LLbqoS6fDya1SQIGc8dA/2ssMXO2xQYzRwYtNIMIZ/ohzjT6kojQ7KVYCPrQUqDuWLBHNYkwY57ukh9hsuKJZ3e07MBxDHRCHWHCQQ82un6MCByFnOLYfEummflxBp3BBhkHZZhy4sCqPbOEK54p22haecX11EIfuqGJVziONbnMpIrZpi82DjYXElaow5jL2A+erncx8JhgxBz3Ff9dbalRXt0rBx7dtOQwOnBw0sITRA6T4bS+44s9WVE40wrEasNMvT3yefLwTyQVCsXDZ2jeee9617tk+tQv/dIvrVzn+z5e85rXYHR0FKVSCS95yUswMzNz3vu666678K//9b9GtVpFsVjEk570JBw/fhxDCTNJf+M38i9evgqguGAVlf8+XM5XIVstiPkvvZWrvxcBs9wxP4iDMjUde0eKMhiB4udcf6AGgoUCeTPRGSUagjDFrqorI2tZGeIAA1YfkywVC8UMJ6yJL5ACOJSKL//HqjCrvRRnYaRJM5luGBJ7JWkJq57H5YaPy3iwe2c7uHemjZONPno86Ug4NS1vLmPCQu5r5n7PZMAFBy2kWopdFQ/XT9UQIoUfJGj2maQQ5MVseU6cbMf9a0FLdKRgE5ktk9RqnJo24mLvaBnjlQKmKpbYJ1gRZzICT2y4b1m1rxccacarubRLeNhTL+IJ+0dxw64q6iULI64N09QwVmK2riUNgowzO77QxdHZrlSMZ5o9qbI/lBSR8x0jq48/xfCxMpGwE2ChE6Av1oY8Ri7T8hMnrlLw9ePUwiROZex2px9jrhNIXvSZlo/FbnA2OUah2ImEw61nhqLCe+utt+JDH/oQHvOYx6y5/g1veAM+9alP4ZOf/KSI19e+9rV48YtfjK985Sub3td9992HZzzjGXjlK1+Jt73tbahUKrjjjjvgumry/DBAkcsP/8GkrF0Vd8Pu9wvlfBWy9YJ4MMlqM4G8xuKwaln7fNtwrmdgGZlUOU83fYwULcm+dQw2oEVY7PnQMx3VKiuIeSPMiphl01Y3lNgsJkzESS8fT+tYUk1lpXo7Y6vEjsHsZC0TawKrqHwtuI08eQ2zPJN35WQihVRjkzTF7ionj2WS0Uv7g58wl5dNaRzHkEnGLqPDcmHBZFwgzpjIkKFSMFGGKaONmZ5QNm3UKyYs3ZSK8EI7EHsDo9sG0BpxeKKMbuigaHfFGsLhFrSVnGj2YZsGxos2wiiROLRGP8JoMZ/ANlV1RXw7+tlms4tFNaBduQwmEnJVhUHMfTZBclz2qlxofp7xBMqk15y53BxBrSdo+3z/6/LeqHqFsyfZ2/2kFIqrkG1/33U6HbzsZS/Dhz/8YbzjHe9Yub7ZbOIjH/kIPv7xj+M5z3mOXPexj30MN954I772ta/hKU95yob395//83/GD//wD+M973nPynXXXHPNZXgmigth/aQsfv9wT0XONxmNImwQMybfL1dyNxLIl2KJ2bMt7BkpYbySyAjlPXVPtse2TIQJq7es5ProhRnafV2qQ0wooOgueaZYF3i5XnZlithAQDIGaztjq/i4nmlgMdPElsGcXg7F4GCHpXYIQ04s8mi2oqXLsAr+XNIMvDx+jFXhgqXh/vmuWBRYud1T81At2VIdZvxa1bVk8hlTFgoOEEcZHNeQhiHHKskJgEN/ZcL9F0mTIbeLVg96LjkS2dJ5AkExQnuBgW6YYarC/OEC9jUCzPshRj0L/TSW9IYgjHA6pIdal4q/puVRbYorJzpstYXg4UwpXJlIGEZIk0RWWBa6vhwbdc+Sk3Z+jlH88r7n2n1ZyeHQlsVWgLm2L1nW3TCUZtDtODlVKBRDIHhpWXjhC1+I5z3veWsE72233YYoiuT6ATfccAP279+PW265ZUPBm6apVITf/OY34wUveAG++c1v4tChQ3jrW9+KH/uxH9t0G4IgkK8BrVZrS5+j4iyDigjFLv/l95cDih/+0Rv4Xc9Vub0U1biSYyBxDDS4xNkLJK6L1R/Ob6Avd75Ly0KMJOUfaR37Ry2pfK9PmBhcHiQGbOcbmI/PyDZWUgceXm4zhQaTFSgSWCkN6EHO6J/VsWe0KB5IVs9lnLJriXeX+bkUwYvdUNIb3CCC4dpi76CXwDW1vPpt6sjSRJ53pmvoceyvp4k5a8JzVvYTtyFmDrDJRrg+DDtfbj4y3Uajz2SHAMGuipxMUIxoSYIk1RHGtJok2DNaQJZqy5Vl3r0myQ8D7/dgtWIgdB7OKoVi62xSMvUwZixgJCdCPK6Yo7zet3+xjYdcleFqAi07HDDD4SSc4DdSsrGn5kr6ShRnEhd4ptlHsxfB7RoyoIUJJBw/UrQtGUG+nq0eGa5QKDZmWz+lP/GJT+Ab3/iGWBrWMz09LZOOarXamusnJyflZxsxOzsrFWP6gSme3/3ud+PTn/602CD+3//7f3jmM5+54e+9853vFPuD4tJDYbC6InI5hMJ2Rz/JRC1Hx5EzbRxb6MpgBzabsbLJBIPHHKjBsznNTEfGQvTyH77VotzcpAFvuxthBtmzq+F20ztL0cHGO1Zm6V+seG4uhJervPzisUABTEvBqUZXlo1pK2j0AT8KpGmPVfCS40jmKau6lkfRmw8IYVLDsYU2pioeDk4UZaodG99oqaBAZo4wm/2OzfVx/0wb35tpousnaIUxMp0jhoE99YKM/NWMBNfVinBNXZasK2y448AITmZb17S21dYcxUOHr8XJRg8nF3s40/DFPsRjb/9IAX6UiG+b1fmSa0suNo8x2hHWv2c2qg6TlWETEjWYiJ+X46s5+OSBhTaaXcYN0mPOqYoZFtq+NF7yPq6fKKMXmXAtTX6XEwtXjx7ntjPZIc3yhsatyNVWKBQbs22f0CdOnMAv/uIv4rOf/eyW+WtZ4SU/+qM/Kv5f8rjHPQ5f/epX8Qd/8AebCl5WgN/4xjeuqfDu27dvS7ZJce6c0gHMsAzY7GRoWx7ls93RT3zMkmVJ0xYzYJvdAPcvdvCI8Soa/Q7Gyh4OjBVErGl6hrHS2WSIwZjieLlKysul5cpnGOvyx/2hVK0uJYPtYTXLNpd9vBYrYBSHa1MK5FiwTXkeYczGNVbAQ1TYE5/lz7Ps5cvAq8f40uowv9jLfc+GhuNLfRG5uq6j4BhSJefACI7y7eqs8Pmy/xhPFiS0RcRodR3UixYYCkcxsmfUE+EyUfWk6s7XgIIklQESHBxxdjn6UlhzFA8N7vtOP0HM46LnI6ZX3LWlyYwrAPyePnAZAtJg86GOqYqNA2OVBw0AGVhgPEuX5lLaZPj6MyOaw2KY3METTYupGxnFK0V0hErBkRjBpU4fpxoBPIs2nwzXT5bl2Gb1N4gZkWfJYzACkKs0PI7p06fNJoxDec8My/tYodhpbJvgpWWBFdmbb7555TrGLX3pS1/C+9//fnzmM59BGIZoNBprqrxMaZiamtrwPsfGxmCaJm4aTPpYhr7fL3/5y5tui+Mw+sjZkueluHgodpmlyqqna2jYP1aUJq2t+uAfhugnVrOZO9vqRfATwEiBVhBJZTAzMokiG6/kkmng0R10h8+0fbS5REr/rqWh60fyR9vQExHLwziwYFDBHQxtOF8sE6vE9DbLZY8Ng7YIjokKr8t/d72Fg5VhihwG/TNOzLE4+jhFoxtj70hBhAYFMBMYivTtBvnJgulH0C0bFcfE7pon4oPJDbRkcCw0b8vt7gZMz+ijGcSwdQ0l++xJxXZZcxSbvbcyNLu+DPboBwEWk768/nPNUJI7OPyD1dXvnmiJeKVP/tk3AQdHc9E7yI+miaUXhHAMC8eXuphp9+WyaWQylIVVWFZjD9YLCLMYWayhr2uS5MGowSDNEEmDmw0OJ+SAFTatSSOmaS1HEHKKn5a/L7IMrm1IJB7FcNGmDUcldigUl4Jt+xv53Oc+F7fffvua617xileIT/ctb3mLVFgty8LnP/95iSMjd999t8SLPfWpT93wPmmBYAQZb7eae+65BwcOHMBQwvF711139vJVCCu7FLuMAeOSf8GJoOv58IatFL3bKQgZzbV/rCSTJU4ucnxv3pRVdvMqJKufgwi01VVdRnVRJDf7ESz6WmWMMVC0bTlcuDzLKWnD2ghzofudt+Prr0GTSptYITz6fBNYpiHh/mQgmOUkpmiJzaHrh1LN5XAKCmAKUHomdY0Nf7mlwnYMXDtVEdHTp3+6F2Fv3cVuxs8VLKkOU3hw2ZrVYkPzpRrPUctsmlsKYqnildzliXrbYM25Ghm8FyhG+XrkJ6+5v32tl9zBYteDaXJcNMQW45g6FjuRNI1ReC60e5jrRCi6Jo7MtbFnuijvnfGiKydkrOxS7NIG0+aQE8bnpRqmO30UHQMjXoqKx0EiTn4CFSYIOJaaMYKaLoJ731Qtt0zYPGkysbdekMa2iKszUSx521V3+XNNVj7YUBug7BmS4Sv2/CE7eVUodoqe2bb3VblcxqMe9ag11zEzl5m7g+sZLUarwcjIiMSLve51rxOxu7phjQKZHtwXvehF8v2b3vQm/Nt/+2/x/d///Xj2s58tHt7/83/+D77whS9gaEfxvexluJqhjYFVNooLR8bDrsqWvQIbOjZqQuHl0aIrGbOjJQ+1gi5TxTohp4ilOLGUL7mzwaYb0b6QSu5rL4jQoN0jjtEMWfF00Q5S7KnZ0kDDBIhhsjM8HChiJgwd1eVEDYoQ7gt2xy92fJmQVnUZXZZPqGPdjN7dJQqbZh9z3T7AyW4VN2+gY7ycmUfAcbodLZaMjmLV1ndTJDpfg0jiz1j57YcpOhyQsdQFE6Inyp5kqXJJm+kR/He1GNnImqPY2vfRdLOHe6e7uHd6SQaAUNheO1nGI6bK8ppRDPeiXHjSY82Tn4mSi2NLHcwu9vDAXA/amVRE7VK/j14AdH1W9guy4tLohBKVJ554GTjjoR9EcE1TKvyLnQBTVU9SP3bV+b7NrS48DjiemscAG9UOjzs4bfFETMMjd1WlWY2NqvQP8zbSoGkbG44/p42Bz4Efd9sVMahQXA16ZqhPJH/3d39XliRZ4WWKApMXPvjBD665Dau5jDAbQOFLvy5F8Otf/3pcf/31+N//+39LNq9iOKFn95qxklRMmN0qUVAGG5MytJcrncPmU73YUceDJrORAqtDiUR2sYqddiANW6xg0WPIiiEnlXF5k3/MWd08OFrCQjcPtB8tuxJhRqsDq5qDmK+dwmBfET7/jEkIcSYnBKNFSzy7efXMkAp5GMa5JWaRYibGFIdPdENUXAtjVUeuo9BgVBlze/XloRZnOr5U/sqS8auLJSJMU5yYbyPkmUaSSTQZR0BT7DATOfcGKzFyOeD7h/Fet963iK8emcOd002xKOytufI+MS0Nu6tsNqR/NxYryyKbxXohTjd8REmMe6dbmGl10fMTtKsWxkfrmHJTjFdKEkc3UXJWJqZJ9NjyNDxWffP3bSlPX0hSea9xBWKlsrz8/mbVViwtpo6DYwU5Llnx54rOenFrXoD150o6sVcorjS0jCYixRrYtMZBFxTSrCwrLv8S5gBaHQbpCoytupBBENsJt73Vjx60zXk3diSePYpd5ulS0E+3A6kisVmKk74o4hiC1exx4EQeh0X/H5MNOAKXQyqy5YijQQzYTj4OZMJV25dpc8wtZtVs/2hRplxxn3Kc6+0nGji52ME0s3/1DOMVB4dGy6gXTNQ8VwZVMLGhG6aYbfZx70wTZ5rMPU6kqnfdBKe1ubAMA984uohOHCOLYkzUijJ0Qmwnnol99YJU4Dldi/0GhmGIZWK1uFERUw8fvq4LvQB3nGri8985g2+fWsBsM5LyzHjBwosffwCPPjiC8bKNqmdjpumL5efIbBNHZnrItBSdbojbTy/JSG6uiDBI5NF7RnB4vIJnXD8hUWEGvd12Pghms9fuXNFzm2X+KhSK4dRrO/Ov5ZUEx+/9zu/kl9/0JhqRcTXDPyKs4FAYcuIYi23bOU1so+071x+5jRIhxIvrx9KNzcotkMLkMAXHwF7xruYeXI7RZV4oq0YUyhS6XLbtstK4nBpwNVSBVkc1UeSPFhzxQ3LNlxXXwUmPWCDKtqRazLQNjNLzCw0Fw5QYqtl2JE2sSTdD0WM6BLv1LWQZPdMpKrYlXt+y58KPU8y3Asn5dRMNkW1LtZC5wDLOuORIUoNn8r7zY7Ig3uksH0FdsKWJ7uHkvSry9xdf+/tnO7j9gSUcW2rKEAcOZ3G5K3lMcPJgkSeMkNfHtnRUYUhjIU9y2CTGdxlPVGgXihFi/0gJh6YqeOSeCh4xWZYmyfXvpY2qsOeyrWx3X4BCMXSEw61n1Pt1GIii7d6CoWAjYTho5BoGkbdRdBGXQVcLm/WJEIRRRlxi5XPKu7TPNpkNYrkGcHoal+ApqCmeZMSxnVeJr4Y/sPGqqCbuL+5WjgseXf75+g52eiX3jnjif75npgEthQgg+pvZmX96sScJDJnGznsTZxo9zLV7+aCCXohq0UEnDFCwLIxUHKS6hqCvY6Efo1a0xPYw3wlwqhmAOS42h2fUPXT9GIenKrKdvN80C2Hy5CbNti3veSfAfdaLIpxu9HHH6SW0wwxJyGmFwEjRxHWTVTzm4Cj2Vovie+WJEP3tdsmW90qKjoyp3lUbkQznBxZ6ckzdsLuCm3ZXcWisKGL3angvKRTbQjS8eka95xVD9ccuD2A3sNQJMVLKhR7/YPXTFFaSbusS/mCABT3GHT9A0XZXKr6rt2rwx3QQK9aNonwcrg2JJFrp0t6A1X+It3t08HYwiGoanBzQe0s2i2rivqEHvOjGODBRgZEBp5t9FJjskLISn0gj2kwrgq5lOLXQhx9nSKDBo6+36GCBld26hgmX0WQcfZdipB/IJC2KV3b81zx25bN6m2CmFaDg0u+ZwdSYEMepFcuDCgxtqFYkrjTkWNcMpEwt8Sz4KaCPZHBdA/vqZTzp0IhYUFipT5GvngwGNty028LuWhFBkkiSAweWtPp5A2i1YKEoo6lV1V2huFpRglcxNAyEHWO46GWl75KVOPpcpfnIMbG3lnc9X26kIhhEEmfFMHrGiC32QowtZ2puBD2o9IryjzJjr0ZKzkrF+kK4kqtQD9XfOGgeQhSjTBsCIMH+HS2WeLCNXntORhsr0wKSylji3VUXScZKLRMuIknD4MoBZ2HNdQLxe7J7LYo0iTvbPVpEuxejttuSrnpuJ1/fbpSg3Q/R6EYSJecvdOF6Fiq2gUOTFUnMSFJOYWN+ai6myNVyknIp/Mq8n7pn4tBkGacaPlzTR1ZxcWisiqkRB4/aXUPFszfM1ubX1LrjY6q6JZulUCh2AFfq31PFDsRcbuYKPVMEhMQMhYk0dbHix3/pdz2X4L0Uf4Tz0aV9zLV89CNGgenYN1qElumSGLDZ49Dz+cB8O58GJkvzpgjenQ5fg/mOL15sJiJwCXm99WMzBkKGto4gTDDXYR5ugk6YSLQUm8gGr//ZRIxMprExK7UXcGyzjRMLXWnum235mKeXV0tk8laj10cv1mQS13jZzLcRGRq2jesmy+L1lPt3LMi4m1pRUiB4/JVcU6qOzE3eO1oQf/VGgv5q+FBdn0ZiaYyY1rYkk5gVewpbvqaNboBMyzDiuagWLfFzny/5QKFQKDZCfV4ohgouXReWxa5Ek2mpJBjQN8t/z7VMvFkk2MMVxFwab/eZsAC0uiF6IcVbhMmat2lqBB8npJVJ0zBesTHd4LS0BCUn3vHNTK1+iGPzPVlK9qME13KgA721Fzg2dRDK3wpC3D3Twqn5LoqejVY5EvvAnlpxzXSsgY+z5NjQtUQe51vtAHfNNGUowGIvkm2ab/aRaECB/W+JgSy2ZPqa52SoF3X0mOW6bkTwoImSP9MlwkoTT/FWTgK8khi8f/jvYN83+gEiyY7meYIhAzm2QvReb+cVXJWCoFAotgIleBVDxUZNX3tqKfoxZ9gbK8vGGzH4Q7xZ09CFCOKNGIyRPd3owbRMiQ9zrLwavdHvsyLMkaSNbiijkjmxiRmyI2V7Q8/vTmw8pMCktzIfzxugXnLghHm28rkqgYP9I1aWho/pRh8nGj50frHS17EwVnJXcprZPNjs9eX1KduZDPaYbrKSG6DTDdD0UzjMPGbmRT7HBJ0MqBZ0aJaGsm7KYApT01H1zAeNCOa28NjjdLtdtYJUm2lhuFrF7uD9E4QxWgGHJYRSYec4Xe4f2k/WnzQ8VFQFV6FQbCU79e/ulQNF3cGDZy8rHvSHbqzsXlBVdqNIsIsRxJtBYba/7sE2gE4/QcHRpdlpo+ou758d5vfMtWVqnGkZ0lHuuFz21nd8M5PsUwOShcv9wDGulq7LpDJWBBe6qTSlUaCOF+0HZdgOBBWnVzE6jNQLlmTmMnXB5NzYZWglyKdjWeK55X3xOkaSmaaBYtGFn/XBgcVZyUGcpUjTDGXbxsExD9WSi7JlwUeGR++qSTPUehHObeOJ1mKWN6PRh83846uF1Tm03Ld8bRj7NRckss89h5PGOI4XOLXUw0jJftBJg0KhuErQhlvPKMG73bAr/OUv3+6tGGoutNKzUSPLajbLyF1/+42u4xLrQdtcGYqxWWqADEvoRwiDGBqHQxj07tri3b0ampkkNcGxEcYpdBgYK5noR6l0zrP+yn3LE5h5TsVilTdOV6bQUVhRFDM/NfZDjJYt7Oq5InJ3m5DmsvHy2RON1dOx+C+/N0wD9ZItKwEVx8Cech3VEqu4Jo7MdtHye5goF/GoPVWxKGg6q78ZbtxVRa344Lokt43bW1heXt/Jwz42864PGkanyrmNg7nQppahULSlwdQxLeyqWhK/N1I4t8deoVDsYKzh1jPqk0lx1YjjjewS6y0OG123pknmAsSqZ2rS0NTpR5ioFkQkXS3Ls4N9Zhse+i5Fbp49Ppgsx5zapW4gt2MtltX2th8ijGk5yC0KQG6HqHs2xopebikwIEJ69YnGZic4e6oFPOnACI5VHFgwsHfMw2TZwfddF8kYWjaf1T0OkohXrDIjpc0X4Xm/bLy7mhjkIbNRs1qwVxpGeeJGjzTHYSes9pZtGGCiio5awUTxHJYjhUKh2E7Up5PiqmK18GQ1dr3FgTwU28MACjL6VYM4Q71kYrx09TU3DU4MNpoMJ5FfTDbIMkRZPrFM13RkWSonCRS79MgOThLOVy3cbDrWtVMV7K4X1lRlpYJbX3u7q6HqfrEMrCVdP0KYJOLDHjSMbvTaErUfFQrFsKME7zCM4nvf+/LLv/RLQzeKbyezmef3XD7g1UjzzjqLg1QdaV+ocIytKWkTO7lJ7Vycb1Tr6qxeTpXjPqc1YSB2H+5jn68qe7VU3TeDcWtBksEx8uEd673urHrTYmIaJiquuaZhdP2+u5r3o0KhuDL0jPqcGgZ6ve3egquSzZbEz+UDHjCYorbQDWVpt1IwUS/k/lKJVnPYuZ7u+Ca1h8PVPlVuu8XuffMdaQZk5vE1Y6UV0Tt4DXj8jlcLYkfZzLOuUCgUV4qeUYJXcUXycAdMrP799WkLF1L54+9yZHAQxWJfaPmxRF5xChQF84WIZsXF7XPF1sHKLsUuJ8vNtPryfWnVa6GOX4VCsdNQf2MUW8qlmHS20WM8lDzd8/3+6gim801zk3HBqQY/5hS1TFIJGDvGJWBWzKQitkXPV6HYamhj4HFKsSvHq7F2FUKdgCgUip2G+pusGBoheqE81Dzdc/1+vC6CaW/N23QwwuA5WrYuUU1+nEBDhGY/lN+lJ1WhGGZoX6CNYSMPr0KhUOxElOBVbFnl9uEK0QvlfAMmHsrvt6NYopdKrrUSwbSR4F3/HCtlS0aqNvsBPI5EpvhVwfuKKwCK3IGNQaFQKHY6SvAqtqxy+3CF6IWK64frMdzo92VogZ5bEgYRTBux/jkO/L9xaq8ZgKBQKBQKhWJ4UIJ3u6E42r377OUh5EIrt1vR7HKh4vrhegzX/z6tCHtq7soggtURTFuV7KBQKBQKxY5FG249o2Ucb6RYQ6vVQrVaRbPZRKVSuer3zuXy5hLm2rb60VnLgGc9KEXhSm64UygUCoVCcfn1mqrwKs7L5YwpuhhbxOrBBfTNrt+2ixWwqjNdoVAoFIqdiRK8igs7UB6GheBihOeFiutB1ZmeWz9KoWkZskxD1cknQvH3+2ECLl9c6qq0QqFQKBSK4UYJ3u0mioAPfCC//JrXAJaFqz0z90IHP0iTmGlirtVFmCRY7IYoOQZGSw5ci2N9M4yVnKt6vK9CoVAoFDtdz1wISgNsN7RQNxpnL18mrpTM3M2gjYFxYH4YQtM0dPwYFddGmqbo+CnKro5eEEpcWMVzVHKCQqFQKBQ7UM9cKErwXqVcKZm5G8Ht7scpsiyFbRjYVdVh6kCzF8EydLgO0O5H0HUdlm7AM3VlZ1AoFAqF4ipGCd6rlEshRM/nyWVVlv9iuar8UC0WA7Fecm3Z/jID9B0b/SiR382QoRPGKHIQBEcAq0EQCoVCoVBc1SjBe5VyOZMX5L5poYiTTS0UF2OxGGxv2w+ha7oIaX5fWE5qICmH/S7flxoEoVAoFArF1Y0SvFcxF9IctlWNbbyPwRSzVj+EjkxG9w7u93wWi/XbQZtCGGtia2iHMbQMaxIZ1CAIhUKhUCgUA5TgVVyWxjZWYbtBgsVOD6zBUvxWPFvSFHi/57JYbLQdtCnomgbPsdDshRyhgqrnrIhlDqtQB7dCoVAoFAoleIcBCrvx8bOXd2hjGwWqbWioFW0kaYIwApyyuVK5pUDdrCq70XasFsi2pUuF91L7kRUKhUKhUFx5eoaoIth2w5w65tXt8MY2/q7nmAjjEBl0eI6GII6lwju4380sFhttx3oPMlFjgRUKhUKh2Cas4dUzRAlexWVpbOPv1j0bBcuQ73l/G40DvpjtWC+Q1cGsUCgUCoViI5RGUDyI9Q1iW3WQyH09RNG8lduhUCgUCoXi6kJpiGEYxfeHf5hffvWrt30U3+WawKZQKBQKhWIHEQ2XnlmPErzbDQcxzM2dvbzN1dzLNYFNoVAoFArFDiLbXj1zPpSWuYrZqJp7uSawKRQKhUKhUFwulOC9itmomnuueDCFQqFQKBSKKxEleK9SKHT5xSkQ66u5W9EgtlUT2hQKhUKhUCgeLkrwXuVWBkpczzbyyWRbJExV45tCoVAoFIphQpXernIrQ/Yw48LOd/+DSq9CoVAoFArFdqEqvNsNbQS12tnLl4FL3ZimGt8UCoVCobjK0C6/nrkYtCxT5bf1tFotVKtVNJtNVCoV7EQutcdWeXgVCoVCoVAMi15TFd6rlEs9uUxNRlMoFAqFQjEsKA+vQqFQKBQKhWJHoyq8wzCK72Mfyy+/4hWbjuJTFgGFQqFQKBRXup7ZLpTg3W5ooT59+uzlDQSuH8ZY6kfQtAxFx5bBECrbVqFQKBQKxbDrmWFBCd4hZJBjG0T8SuRy249R9fKzpYJtqBdOoVAoFAqF4gJRHt4hhJVdit04BeY7IZa6oYjdZj9ClmlrYsQojoM4yaemKRQKhUKhUCgehKrwDiEUtJqmoeOHqBUspCKAU4wWHdQ9a8XOoCaaKRQKhUKhUFxBFd53vetdIvJ+6Zd+aeU63/fxmte8BqOjoyiVSnjJS16CmZmZc97Py1/+crmf1V8/+IM/iCsJCtqqa6FedFBwTOwbKeDgWBH7RwooefbK7dREM4VCoVAoFIorpMJ766234kMf+hAe85jHrLn+DW94Az71qU/hk5/8pAQLv/a1r8WLX/xifOUrXznn/VHgfmzQKQjAcRxcabh23ph2ruEQaqKZQqFQKBQKxRUgeDudDl72spfhwx/+MN7xjnesXM+pGR/5yEfw8Y9/HM95znPkOorYG2+8EV/72tfwlKc8ZdP7pMCdmpp6+BsXhvnXenQdMFftuo1uM4B+29XRHOtvy+9t+2ykx+AyX5w0oW9BRC/Wi15+b1mS2CCiOI5hJjGQXMA28HHO1UG5ahsu6rZxDKTp1tyW2zvwKl+q2yZJ/rUVt+XxwONiWG7LfcB9sRmGkX8Ny215jPFY24rbrn5/Xqrbnu99v5WfEee67bnen5fqtkR9RuSoz4gc9RmRc7V/RoSr9MxqLqWOONe+GDbBS8vCC1/4Qjzvec9bI3hvu+02RFEk1w+44YYbsH//ftxyyy3nFLxf+MIXMDExgXq9LmKZ90tbxGYEQSBfq0fVCe99L9Xzg3/huuuAl73s7Pe/8zub/6E8eJA+i7Pfv+99QK+38W3//M+BV7965dvk99+PaGERaZoh1TXohg5dXxZg4+PceWcnmn3oD4C5uY3vl7OtV1lFJCdvEB2ynkIBePOb127TsWMb35YH/3/+z2e//4u/AO69F5vyG79x9vJf/RVw552b3/ZXfuXsgf3//X/At761+W3f9CagWMwvf+YzXDLY/LbcD4NZ35//PPDVr25+2//wH4CJifzyP/0TD6zNb/uqVwF79uSXv/Y14LOf3fy2PB54XJDbbgP+/u83v+1P/RTwiEfkl2+/Hfibv9n8tv/m3wCPfGR++a67gE9+cvPb/tiPAY97XH75yBHg4x/f/LY//MPAk5+cXz5+HPijP9r8tj/wA8DTn55fPnMG+PCHN7/ts56VfxEeux/84Oa3fdrTgOc/P7/cbObvo8140pOAF74wv8z3Gt+fm8F9wH1B+B7+7d/e/LY33QT8xE+c/f5ct71UnxG7d6/5jMAHPgA0GhvfdvkzYoU//EP1GUHUZ0R+PKjPiHw/qM8IXJLPiNXC9FLqiG9+E1eE4P3EJz6Bb3zjG2JpWM/09DRs20ZtIE6WmZyclJ+dy85A28OhQ4dw33334Vd+5VfwQz/0QyKSjUGFaB3vfOc78ba3vQ3DRpZlInYtQ0eUpEiNDDrOJjQoFAqFQqFQKM6PllFVbQMnTpzAE5/4RHz2s59d8e4+61nPwuMe9zi8733vEyvDK17xijWVV/LkJz8Zz372s/Hud7/7gh7n/vvvxzXXXIPPfe5zeO5zn3vBFd59+/ahOTeHSqWybUsRsR+g7UeSxsBK7pqBE2q58izK0pCjLA0Pfn8qS8PZ94myNCx/sCrb09BYmZTtaWdZGrbB9tRqNFAdHxcb7IZ6bRgqvLQszM7O4uabb165LkkSfOlLX8L73/9+fOYzn0EYhmg0GmuqvExpuBh/7uHDhzE2NoYjR45sKnjp+d2wsY07diM/yka3u1DW35YHAsv9ZPUSKF8c10HZss7ZuLbCxYzwu1S3XX0ScCXcdvUH7067LUXfhR6Xw3BbfpheSbclw3DbYXjfq8+I4Xnfq8+IHPUZ8dDen9bDvO16PTO4zaX8jLiIz8ttE7wUn7fTk7gKVnTp033LW94iFVbLsvD5z39e4sjI3XffjePHj+OpT33qBT/OyZMnsbCwgF27dmEo4VnPwNuywRnQikdXoVAoFAqFYljJzq1ntptt01LlchmPetSj1lxXLBaluWxw/Stf+Uq88Y1vxMjIiJSqX/e614nYXd2wRoFMD+6LXvQiSXygF5cCmVVgenjf/OY349prr8ULXvCCy/4cFQqFQqFQKBTbz1AXD3/3d38Xuq6LgKXHlqL1g+s6uVn1pXeDsCntO9/5Dv74j/9YrBC7d+/G85//fLz97W+/IrN4FQqFQqFQKBQ7TPAyTmw1ruviAx/4gHxtxuqeO8/zxPurUCgUCoVCoVAM3WhhhUKhUCgUCoXiUqAEr0KhUCgUCoViRzNUloarlouJ7FAoFAqFQqEYRqzh1TPbNnhimOHgiWq1ekFBxgqFQqFQKBSK4dZrytKgUCgUCoVCodjRKMGrUCgUCoVCodjRKA/vdsO50X/xF/nlf/tvL26snkKhUCgUCsUwEA+3nhmurbkaSVPg3nvPXlYoFAqFQqG40kiHW88oS4NCoVAoFAqFYkejBK9CoVAoFAqFYkejBK9CoVAoFAqFYkejBK9CoVAoFAqFYkejBK9CoVAoFAqFYkejUho2YDB8jhM8LjlhCARBfpmPZ9uX/jEVCoVCoVAornA9M9BpFzI0WI0W3oCTJ09i3759W//KKBQKhUKhUCi2lBMnTmDv3r3nvI0SvBuQpilOnz6NcrkMTdNwtcIzJwp/Hkjnm1F9taP2ldpX6rjaftT7UO0rdVxdXe/BLMvQbrexe/du6Pq5XbrK0rAB3GnnO1O4muBBqwSv2lfquFLvwSsF9Zml9pU6rq6e92C1Wr2g26mmNYVCoVAoFArFjkYJXoVCoVAoFArFjkYJXsWmOI6DX//1X5d/FedG7asLR+0rta8uFerYUvtKHVfbizPEukE1rSkUCoVCoVAodjSqwqtQKBQKhUKh2NEowatQKBQKhUKh2NEowatQKBQKhUKh2NEowatQKBQKhUKh2NEowXuV8oUvfEGmyG30deuttz7o9keOHJHJc7Va7Zz3++1vfxsvfelLZdKK53m48cYb8Xu/93u4krlU+4q8/vWvxxOe8ATpaH3c4x6HncCl3F/Hjx/HC1/4QhQKBUxMTOBNb3oT4jjGTt5Xd999N5797GdjcnISruvi8OHD+C//5b8giqJz3vfnP/95PO1pT5N9OzU1hbe85S1qX20C9/Vzn/tcOQbr9Tpe8IIXyGfZlcqlOq7+6I/+aNP7nZ2dxZXIpXwPDvbZYx7zGPk9fma95jWvwZXKFy7hvtroPj/xiU9s7RPIFFclQRBkZ86cWfP1C7/wC9mhQ4eyNE3X3DYMw+yJT3xi9kM/9ENZtVo95/1+5CMfyV7/+tdnX/jCF7L77rsv+9M//dPM87zs93//97MrlUu1r8jrXve67P3vf3/2Mz/zM9ljH/vYbCdwqfZXHMfZox71qOx5z3te9s1vfjP7+7//+2xsbCx761vfmu3kfcX30Uc/+tHsW9/6Vnbs2LHsb//2b7OJiYlzPm/e1rbt7G1ve1t27733yvvxhhtuyH75l385u1K5VPuq3W5nIyMj2ctf/vLse9/7Xvbd7343e8lLXpJNTk7K8Xklcqn2Va/Xe9D9vuAFL8ie+cxnZlcql2pfkfe+973Z7t27sz//8z/Pjhw5kn3729+W371SCS7hvqIc/djHPrbmvvv9/pZuvxK8CoEf7OPj49lv/uZvPmiPvPnNb85++qd/Wg7GCxFx6/kP/+E/ZM9+9rN3zJ6+FPvq13/913eM4L1U+4sCV9f1bHp6euW6//7f/3tWqVTkg3in76vVvOENb8ie8YxnbPpz/nHhicRq/u7v/i5zXTdrtVrZTmCr9tWtt94qf2yPHz++ct13vvMduY4nCzuBrdpX65mdnc0sy8r+5E/+JNspbNW+WlxclGLP5z73uWynEm7hccX321//9V9nlxJlaVAIf/d3f4eFhQW84hWvWLNH/u///b/45Cc/iQ984AMPeU81m02MjIzsmD19KffVTmSr9tctt9yCRz/60bJUNoBLz61WC3fccQd28r5abwH59Kc/jWc+85mb3iYIAllOXA0tRr7v47bbbsNOYKv21fXXX4/R0VF85CMfQRiG6Pf7cpl2rIMHD2InsFX7aj1/8id/IvaiH//xH8dOYav21Wc/+1mkaYpTp07JsbR37178xE/8BE6cOIGdwt9t8XFFu8fY2Bie/OQn46Mf/SgLslu7wZdUTiuuGLikzK/VzM/PZ/v27cu++MUvyvcPpcL7la98JTNNM/vMZz6T7RQuxb7ayRXerdpfr3rVq7LnP//5a67rdrtSGWD1d6fuqwFPfepTM8dx5Pm++tWvzpIk2fR++H5jNfzjH/+4WEFOnjyZ/at/9a/kd3ndTmCr9hW5/fbbs2uuuUb2Gb+uv/56WY7dKWzlvlrNjTfemP37f//vs53EVu2rd77znVL95rH06U9/Orvllluy5z73ufL9TlmR+qEtPK5YJf7yl7+cfeMb38je9a53ye/+3u/93pZurxK8O4y3vOUtcoCd6+uuu+5a8zsnTpyQD/m//Mu/XHP9i170Irm/ARcr4vhHhB7Lt7/97dkwMkz76koQvNu9v64kwbuV+2oAl9zvuOMOEax79uzJ3v3ud5/XP0i7h2EYWaFQkD/AfNxPfOIT2TCx3fuKvtQnP/nJ2c/+7M9mX//610WY0MP7yEc+Un42TGz3vlrNV7/6VXm8f/mXf8mGke3eV7/1W78lj7G62EMLCO+fAniYeMsQHVcDfvVXfzXbu3dvtpWo0cI7jLm5OVliOBfsmrRte+X7t7/97fj93/99WXqxLGvlenYsdzqdle95gsQlGsMw8Id/+If4+Z//+U0f484775ROzV/4hV/Ab/3Wb2EYGZZ9RX7jN34Df/M3f4NvfetbGFa2e3/92q/9miyhrd5HR48elcf8xje+gcc//vHYiftqI/7sz/4Mr371q9Fut2WfbQb365kzZyR54NixY7jpppvw9a9/HU960pMwLGz3vqJ94Vd+5VdkP+l67vKjtYH7jD/7yZ/8SQwL272vVvPKV75S3nff/OY3MYxs97762Mc+Jp9jtDDQzjCAlqx3vOMdeNWrXoVhYW6IjqsBn/rUp/AjP/IjYsNiitFWYG7JvSiGhvHxcfm6UPgHkW/Mn/3Zn33QQUvPZJIkK9//7d/+Ld797nfjq1/9Kvbs2bPpfdJP+ZznPAc/93M/N7Rid1j21ZXEdu+vpz71qXI8Mf6I8T4Dn1ylUhEht1P31Ubw5IAxP4OThM1gtM/u3bvl8v/8n/9T4gJvvvlmDBPbva96vZ4IXe6rAYPv+TvDxHbvqwE8Wf1f/+t/4Z3vfCeGle3eV09/+tNXYroGgndxcRHz8/M4cOAAhonxITmuVsPCBk86t0rsCltaL1ZccbCDdKPlio3YaNn5r/7qr8STtNrGwK5Ndt6vjhfhUs6VzlbvK8IucEZs/bt/9++yRzziEXKZXzvB47XV+2sQS0ZbAyNvuCzIY+1KjiW7kH31Z3/2Z9lf/MVfZHfeeadE/vAyo45e9rKXnfPYes973iNpA4zZoj+OfsJL3QV9Je4r3g/9gvSi8ve4v/j5xePx9OnT2ZXMpTiuyP/4H/9DEj+WlpayncKl2Fc/+qM/KtYY9rLwb+OP/MiPZDfddNMVG3d3qfYVE2Q+/OEPyz7i38QPfvCDYsP6tV/7tWwrUYL3KuelL31p9rSnPe2CbruRKOF1q8+b6EXdyP9z4MCB7Epnq/cVYX7lRvvr6NGj2ZXOpdhfbCRikwTjfugPZ65sFEXZTt5X9NzefPPNWalUyorFovzB/O3f/u01GZUb7StGAXKfUph83/d939D5nIdpX/3jP/5j9vSnP132V71ez57znOeIl/dK51Lsq0FD0k/91E9lO4lLsa+azWb28z//81mtVpOsZ/YurI6/u1J56Rbvq3/4h3/IHve4x638DvtZ/uAP/uCiGigvBOXhVSgUCoVCoVDsaFQOr0KhUCgUCoViR6MEr0KhUCgUCoViR6MEr0KhUCgUCoViR6MEr0KhUCgUCoViR6MEr0KhUCgUCoViR6MEr0KhUCgUCoViR6MEr0KhUCgUCoViR6MEr0KhUCgUCoViR6MEr0KhUFxGnvWsZ+GXfumXdsxjvvzlL8eP/diPXZL7VigUiq3C3LJ7UigUCsVQ8ld/9VewLGvl+4MHD4oAvtzCW6FQKLYLJXgVCoVihzMyMrLdm6BQKBTbirI0KBQKxTaxtLSEn/3Zn0W9XkehUMAP/dAP4d577135+R/90R+hVqvhM5/5DG688UaUSiX84A/+IM6cObNymziO8frXv15uNzo6ire85S34uZ/7uTU2g9WWBl5+4IEH8IY3vAGapskX+Y3f+A087nGPW7N973vf+6QaPCBJErzxjW9ceaw3v/nNyLJsze+kaYp3vvOdOHToEDzPw2Mf+1j85V/+5SXYewqFQnHhKMGrUCgU2wT9r//yL/+Cv/u7v8Mtt9wi4vGHf/iHEUXRym16vR7+63/9r/jTP/1TfOlLX8Lx48fxH//jf1z5+bvf/W78+Z//OT72sY/hK1/5ClqtFv7mb/7mnPaGvXv34jd/8zdFOK8Wz+fjve99r4jwj370o/jyl7+MxcVF/PVf//Wa21Ds/smf/An+4A/+AHfccYcI65/+6Z/GF7/4xYvePwqFQrFVKEuDQqFQbAOs5FLoUqQ+7WlPk+soXPft2yeC9d/8m38j11H8Ujxec8018v1rX/taEasDfv/3fx9vfetb8aIXvUi+f//734+///u/P6e9wTAMlMtlTE1NXdQ2s+LLx3rxi18s33O7WH0eEAQBfvu3fxuf+9zn8NSnPlWuO3z4sIjjD33oQ3jmM595UY+nUCgUW4USvAqFQrEN3HXXXTBNE9/3fd+3ch1tAtdff738bACtDgOxS3bt2oXZ2Vm53Gw2MTMzgyc/+ckrP6eYfcITniDWgq2Ej8Vq8Ort5fY/8YlPXLE1HDlyRCrSP/ADP7Dmd8MwxOMf//gt3R6FQqG4GJTgVSgUiiFmdboCoed2vW92K9B1/UH3u9pacSF0Oh3591Of+hT27Nmz5meO42zBVioUCsVDQ3l4FQqFYhtgExobzv75n/955bqFhQXcfffduOmmmy7oPqrVKiYnJ3HrrbeuaSz7xje+cc7fs21bbrea8fFxTE9PrxG93/rWt9Y8FqvLq7eX23/bbbetfM/tprClz/jaa69d80WrhkKhUGwXqsKrUCgU28B1112HH/3RH8WrXvUq8bfSU/uf/tN/ksoor79QXve610mjGEXlDTfcIJ5epj8M0hc2gskLbID7yZ/8SRGoY2Njkt4wNzeH97znPfjxH/9xfPrTn8Y//MM/oFKprPzeL/7iL+Jd73qXbDsf67/9t/+GRqOx8nM+BzbUsVGNlopnPOMZYoWgT5n3w/QIhUKh2A5UhVehUCi2CSYr0G/7Iz/yI9LkxeoqG87W2xjOBWPIXvrSl0q8Ge+D0WUveMEL4Lrupr/Dprdjx46JN5iV3UHF+YMf/CA+8IEPSJTY17/+9TVpEOSXf/mX8TM/8zMiXPlYFLiDZrkBb3/72/Grv/qrIsJ5n4xRo8WBMWUKhUKxXWjZpTCDKRQKhWJbYGWVQvMnfuInRHwqFAqFQlkaFAqF4oqGQyT+8R//USK/GAvGWLKjR4/ip37qp7Z70xQKhWJoUJYGhUKhuIJhugKHQTzpSU/C05/+dNx+++2Sg8sqr0KhUChylKVBoVAoFAqFQrGjURVehUKhUCgUCsWORglehUKhUCgUCsWORglehUKhUCgUCsWORglehUKhUCgUCsWORglehUKhUCgUCsWORglehUKhUCgUCsWORglehUKhUCgUCsWORglehUKhUCgUCgV2Mv9/2FggmesRGc4AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 800x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig, ax = plt.subplots(figsize=(8, 6))\n",
     "df.plot.scatter(x='longitude', y='latitude', alpha=0.05, s=4, ax=ax)\n",
@@ -248,20 +852,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "datetime-before",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:38.228338Z",
+     "iopub.status.busy": "2026-05-14T05:21:38.228219Z",
+     "iopub.status.idle": "2026-05-14T05:21:38.231575Z",
+     "shell.execute_reply": "2026-05-14T05:21:38.231122Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    2018-10-19\n",
+       "1    2019-05-21\n",
+       "2           NaN\n",
+       "3    2019-07-05\n",
+       "4    2018-11-19\n",
+       "Name: last_review, dtype: object"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df['last_review'].head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "datetime-after",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:38.233035Z",
+     "iopub.status.busy": "2026-05-14T05:21:38.232918Z",
+     "iopub.status.idle": "2026-05-14T05:21:38.241666Z",
+     "shell.execute_reply": "2026-05-14T05:21:38.241011Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0   2018-10-19\n",
+       "1   2019-05-21\n",
+       "2          NaT\n",
+       "3   2019-07-05\n",
+       "4   2018-11-19\n",
+       "Name: last_review, dtype: datetime64[ns]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "pd.to_datetime(df['last_review']).head()"
    ]
@@ -278,43 +928,68 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "neighborhood-counts",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:38.242921Z",
+     "iopub.status.busy": "2026-05-14T05:21:38.242802Z",
+     "iopub.status.idle": "2026-05-14T05:21:38.247608Z",
+     "shell.execute_reply": "2026-05-14T05:21:38.246960Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "neighbourhood_group\n",
+       "Manhattan        21661\n",
+       "Brooklyn         20104\n",
+       "Queens            5666\n",
+       "Bronx             1091\n",
+       "Staten Island      373\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df['neighbourhood_group'].value_counts()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "roomtype-counts",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:38.248887Z",
+     "iopub.status.busy": "2026-05-14T05:21:38.248779Z",
+     "iopub.status.idle": "2026-05-14T05:21:38.253107Z",
+     "shell.execute_reply": "2026-05-14T05:21:38.252521Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "room_type\n",
+       "Entire home/apt    25409\n",
+       "Private room       22326\n",
+       "Shared room         1160\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df['room_type'].value_counts()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "profile-md",
-   "metadata": {},
-   "source": [
-    "## 9. Full profiling report\n",
-    "\n",
-    "Generate a ydata-profiling report for a single-page overview — useful as a reference artifact but not used for any specific decision below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "profile-code",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "profile = ProfileReport(df, title=\"NYC Airbnb raw sample\", minimal=True)\n",
-    "profile.to_widgets()"
    ]
   },
   {
@@ -329,10 +1004,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "apply-code",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:38.254663Z",
+     "iopub.status.busy": "2026-05-14T05:21:38.254480Z",
+     "iopub.status.idle": "2026-05-14T05:21:38.273241Z",
+     "shell.execute_reply": "2026-05-14T05:21:38.272606Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Raw rows:       48,895\n",
+      "Cleaned rows:   46,427\n",
+      "Dropped:         2,468  (5.0%)\n"
+     ]
+    }
+   ],
    "source": [
     "min_price, max_price = 10, 350\n",
     "\n",
@@ -353,10 +1045,205 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "verify-code",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:38.274743Z",
+     "iopub.status.busy": "2026-05-14T05:21:38.274618Z",
+     "iopub.status.idle": "2026-05-14T05:21:38.298022Z",
+     "shell.execute_reply": "2026-05-14T05:21:38.297504Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>host_id</th>\n",
+       "      <th>latitude</th>\n",
+       "      <th>longitude</th>\n",
+       "      <th>price</th>\n",
+       "      <th>minimum_nights</th>\n",
+       "      <th>number_of_reviews</th>\n",
+       "      <th>last_review</th>\n",
+       "      <th>reviews_per_month</th>\n",
+       "      <th>calculated_host_listings_count</th>\n",
+       "      <th>availability_365</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>4.642700e+04</td>\n",
+       "      <td>4.642700e+04</td>\n",
+       "      <td>46427.000000</td>\n",
+       "      <td>46427.000000</td>\n",
+       "      <td>46427.000000</td>\n",
+       "      <td>46427.000000</td>\n",
+       "      <td>46427.000000</td>\n",
+       "      <td>37246</td>\n",
+       "      <td>37246.000000</td>\n",
+       "      <td>46427.000000</td>\n",
+       "      <td>46427.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>1.891825e+07</td>\n",
+       "      <td>6.645123e+07</td>\n",
+       "      <td>40.728577</td>\n",
+       "      <td>-73.950962</td>\n",
+       "      <td>122.538286</td>\n",
+       "      <td>6.943287</td>\n",
+       "      <td>23.828225</td>\n",
+       "      <td>2018-10-02 16:44:07.564839168</td>\n",
+       "      <td>1.377473</td>\n",
+       "      <td>6.672626</td>\n",
+       "      <td>109.671377</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>2.539000e+03</td>\n",
+       "      <td>2.438000e+03</td>\n",
+       "      <td>40.506410</td>\n",
+       "      <td>-74.244420</td>\n",
+       "      <td>10.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>2011-03-28 00:00:00</td>\n",
+       "      <td>0.010000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>9.445422e+06</td>\n",
+       "      <td>7.719010e+06</td>\n",
+       "      <td>40.689360</td>\n",
+       "      <td>-73.982095</td>\n",
+       "      <td>65.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>2018-07-02 06:00:00</td>\n",
+       "      <td>0.190000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>1.954477e+07</td>\n",
+       "      <td>3.032062e+07</td>\n",
+       "      <td>40.722010</td>\n",
+       "      <td>-73.954570</td>\n",
+       "      <td>100.000000</td>\n",
+       "      <td>2.000000</td>\n",
+       "      <td>5.000000</td>\n",
+       "      <td>2019-05-19 00:00:00</td>\n",
+       "      <td>0.715000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>40.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>2.893796e+07</td>\n",
+       "      <td>1.056405e+08</td>\n",
+       "      <td>40.763330</td>\n",
+       "      <td>-73.934625</td>\n",
+       "      <td>160.000000</td>\n",
+       "      <td>5.000000</td>\n",
+       "      <td>24.000000</td>\n",
+       "      <td>2019-06-23 00:00:00</td>\n",
+       "      <td>2.020000</td>\n",
+       "      <td>2.000000</td>\n",
+       "      <td>217.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>3.648724e+07</td>\n",
+       "      <td>2.743213e+08</td>\n",
+       "      <td>40.913060</td>\n",
+       "      <td>-73.712990</td>\n",
+       "      <td>350.000000</td>\n",
+       "      <td>1250.000000</td>\n",
+       "      <td>629.000000</td>\n",
+       "      <td>2019-07-08 00:00:00</td>\n",
+       "      <td>58.500000</td>\n",
+       "      <td>327.000000</td>\n",
+       "      <td>365.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>1.093126e+07</td>\n",
+       "      <td>7.769209e+07</td>\n",
+       "      <td>0.055181</td>\n",
+       "      <td>0.046367</td>\n",
+       "      <td>71.863331</td>\n",
+       "      <td>19.877710</td>\n",
+       "      <td>45.190872</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.690493</td>\n",
+       "      <td>31.083760</td>\n",
+       "      <td>130.410015</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 id       host_id      latitude     longitude         price  \\\n",
+       "count  4.642700e+04  4.642700e+04  46427.000000  46427.000000  46427.000000   \n",
+       "mean   1.891825e+07  6.645123e+07     40.728577    -73.950962    122.538286   \n",
+       "min    2.539000e+03  2.438000e+03     40.506410    -74.244420     10.000000   \n",
+       "25%    9.445422e+06  7.719010e+06     40.689360    -73.982095     65.000000   \n",
+       "50%    1.954477e+07  3.032062e+07     40.722010    -73.954570    100.000000   \n",
+       "75%    2.893796e+07  1.056405e+08     40.763330    -73.934625    160.000000   \n",
+       "max    3.648724e+07  2.743213e+08     40.913060    -73.712990    350.000000   \n",
+       "std    1.093126e+07  7.769209e+07      0.055181      0.046367     71.863331   \n",
+       "\n",
+       "       minimum_nights  number_of_reviews                    last_review  \\\n",
+       "count    46427.000000       46427.000000                          37246   \n",
+       "mean         6.943287          23.828225  2018-10-02 16:44:07.564839168   \n",
+       "min          1.000000           0.000000            2011-03-28 00:00:00   \n",
+       "25%          1.000000           1.000000            2018-07-02 06:00:00   \n",
+       "50%          2.000000           5.000000            2019-05-19 00:00:00   \n",
+       "75%          5.000000          24.000000            2019-06-23 00:00:00   \n",
+       "max       1250.000000         629.000000            2019-07-08 00:00:00   \n",
+       "std         19.877710          45.190872                            NaN   \n",
+       "\n",
+       "       reviews_per_month  calculated_host_listings_count  availability_365  \n",
+       "count       37246.000000                    46427.000000      46427.000000  \n",
+       "mean            1.377473                        6.672626        109.671377  \n",
+       "min             0.010000                        1.000000          0.000000  \n",
+       "25%             0.190000                        1.000000          0.000000  \n",
+       "50%             0.715000                        1.000000         40.000000  \n",
+       "75%             2.020000                        2.000000        217.000000  \n",
+       "max            58.500000                      327.000000        365.000000  \n",
+       "std             1.690493                       31.083760        130.410015  "
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df_clean.describe()"
    ]
@@ -373,10 +1260,55 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "finish-code",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-14T05:21:38.299548Z",
+     "iopub.status.busy": "2026-05-14T05:21:38.299410Z",
+     "iopub.status.idle": "2026-05-14T05:21:39.825638Z",
+     "shell.execute_reply": "2026-05-14T05:21:39.821639Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: updating run metadata; uploading summary\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: uploading summary; uploading wandb-metadata.json; uploading requirements.txt; uploading wandb-summary.json\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: uploading wandb-metadata.json; uploading requirements.txt; uploading wandb-summary.json; uploading config.yaml\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: 🚀 View run \u001b[33mdevoted-capybara-27\u001b[0m at: \u001b[34m\u001b[4mhttps://wandb.ai/fahd-alshal-general-organization-for-social-insurance/nyc_airbnb/runs/ruzvc4me\u001b[0m\n",
+      "\u001b[34m\u001b[1mwandb\u001b[0m: ⭐️ View project at: \u001b[34m\u001b[4mhttps://wandb.ai/fahd-alshal-general-organization-for-social-insurance/nyc_airbnb\u001b[0m\n",
+      "\u001b[34m\u001b[1mwandb\u001b[0m: Synced 4 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: Find logs at: \u001b[35m\u001b[1m./wandb/run-20260514_082131-ruzvc4me/logs\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "run.finish()"
    ]
@@ -398,7 +1330,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.0"
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,

--- a/src/eda/conda.yml
+++ b/src/eda/conda.yml
@@ -13,4 +13,4 @@ dependencies:
   - ipywidgets=8.1.7
   - pip:
       - mlflow==3.3.2
-      - wandb==0.21.3
+      - wandb==0.26.1

--- a/src/train_random_forest/conda.yml
+++ b/src/train_random_forest/conda.yml
@@ -11,4 +11,4 @@ dependencies:
   - scikit-learn=1.7.2
   - pip:
       - mlflow==3.3.2
-      - wandb==0.21.3
+      - wandb==0.26.1

--- a/src/train_random_forest/run.py
+++ b/src/train_random_forest/run.py
@@ -9,6 +9,7 @@ import shutil
 import matplotlib.pyplot as plt
 
 import mlflow
+import mlflow.sklearn
 import json
 
 import pandas as pd
@@ -51,11 +52,7 @@ def go(args):
     # Fix the random seed for the Random Forest, so we get reproducible results
     rf_config['random_state'] = args.random_seed
 
-    ######################################
-    # Use run.use_artifact(...).file() to get the train and validation artifact (args.trainval_artifact)
-    # and save the returned path in train_local_path
-    trainval_local_path = # YOUR CODE HERE
-    ######################################
+    trainval_local_path = run.use_artifact(args.trainval_artifact).file()
 
     X = pd.read_csv(trainval_local_path)
     y = X.pop("price")  # this removes the column "price" from X and puts it into y
@@ -73,10 +70,7 @@ def go(args):
     # Then fit it to the X_train, y_train data
     logger.info("Fitting")
 
-    ######################################
-    # Fit the pipeline sk_pipe by calling the .fit method on X_train and y_train
-    # YOUR CODE HERE
-    ######################################
+    sk_pipe.fit(X_train, y_train)
 
     # Compute r2 and MAE
     logger.info("Scoring")
@@ -94,30 +88,22 @@ def go(args):
     if os.path.exists("random_forest_dir"):
         shutil.rmtree("random_forest_dir")
 
-    ######################################
-    # Save the sk_pipe pipeline as a mlflow.sklearn model in the directory "random_forest_dir"
-    # HINT: use mlflow.sklearn.save_model
-    # YOUR CODE HERE
-    ######################################
+    mlflow.sklearn.save_model(sk_pipe, "random_forest_dir")
 
-    ######################################
-    # Upload the model we just exported to W&B
-    # HINT: use wandb.Artifact to create an artifact. Use args.output_artifact as artifact name, "model_export" as
-    # type, provide a description and add rf_config as metadata. Then, use the .add_dir method of the artifact instance
-    # you just created to add the "random_forest_dir" directory to the artifact, and finally use
-    # run.log_artifact to log the artifact to the run
-    # YOUR CODE HERE
-    ######################################
+    artifact = wandb.Artifact(
+        args.output_artifact,
+        type="model_export",
+        description="Random Forest pipeline exported via mlflow.sklearn",
+        metadata=rf_config,
+    )
+    artifact.add_dir("random_forest_dir")
+    run.log_artifact(artifact)
 
     # Plot feature importance
     fig_feat_imp = plot_feature_importance(sk_pipe, processed_features)
 
-    ######################################
-    # Here we save r_squared under the "r2" key
     run.summary['r2'] = r_squared
-    # Now log the variable "mae" under the key "mae".
-    # YOUR CODE HERE
-    ######################################
+    run.summary['mae'] = mae
 
     # Upload to W&B the feture importance visualization
     run.log(
@@ -152,12 +138,10 @@ def get_inference_pipeline(rf_config, max_tfidf_features):
     # (nor during training). That is not true for neighbourhood_group
     ordinal_categorical_preproc = OrdinalEncoder()
 
-    ######################################
-    # Build a pipeline with two steps:
-    # 1 - A SimpleImputer(strategy="most_frequent") to impute missing values
-    # 2 - A OneHotEncoder() step to encode the variable
-    non_ordinal_categorical_preproc = # YOUR CODE HERE
-    ######################################
+    non_ordinal_categorical_preproc = make_pipeline(
+        SimpleImputer(strategy="most_frequent"),
+        OneHotEncoder(),
+    )
 
     # Let's impute the numerical columns to make sure we can handle missing values
     # (note that we do not scale because the RF algorithm does not need that)
@@ -218,12 +202,12 @@ def get_inference_pipeline(rf_config, max_tfidf_features):
     # Create random forest
     random_forest = RandomForestRegressor(**rf_config)
 
-    ######################################
-    # Create the inference pipeline. The pipeline must have 2 steps: a step called "preprocessor" applying the
-    # ColumnTransformer instance that we saved in the `preprocessor` variable, and a step called "random_forest"
-    # with the random forest instance that we just saved in the `random_forest` variable.
-    # HINT: Use the explicit Pipeline constructor so you can assign the names to the steps, do not use make_pipeline
-    sk_pipe = # YOUR CODE HERE
+    sk_pipe = Pipeline(
+        steps=[
+            ("preprocessor", preprocessor),
+            ("random_forest", random_forest),
+        ]
+    )
 
     return sk_pipe, processed_features
 


### PR DESCRIPTION
- basic_cleaning: new step that drops price outliers, parses last_review, and filters to NYC bounding box (so test_proper_boundaries holds on future samples like sample2.csv)
- data_check: add test_row_count and test_price_range
- train_random_forest: fill in artifact fetch, OHE preprocessing pipeline, fit call, model save/upload, and mae summary logging
- main.py: wire basic_cleaning, data_check, data_split, train_random_forest, and test_regression_model into the orchestrator
- Bake winning sweep hyperparameters into config.yaml (max_tfidf_features=30, random_forest.max_features=0.33)
- Bump wandb==0.21.3 to 0.26.1 across all 9 yml files; 0.21.3 enforces a 40-char API key client-side, which is incompatible with W&B's newer wandb_v1_* PAT format issued to new accounts.